### PR TITLE
Add WebArena and tau-bench to Benchmarks and Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ Learning resources for AI-powered testing.
 - [BenchClaw](https://github.com/Agnuxo1/BenchClaw) 🆓 - Multi-dimension AI benchmark with 17-judge evaluation tribunal for scientific paper generation. Evaluates IMRaD structure, citation quality, methodological rigor, and reproducibility across 10 dimensions with uncertainty quantification and P2P verification.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
+- [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
+- [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
@
Adds two widely used autonomous agent benchmarks to the Benchmarks and Datasets section, which previously only covered code generation benchmarks.

- WebArena (https://github.com/web-arena-x/webarena) - self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
- tau-bench (https://github.com/sierra-research/tau-bench) - benchmark for tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.

Both entries follow the existing list format and link to active open source repositories.

Closes #10
@