### PR TITLE
Add: Opik and Guardrails AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) 🆓 - EleutherAI's framework for few-shot evaluation of language models, backing the Hugging Face Open LLM Leaderboard.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
 - [Helicone](https://github.com/Helicone/helicone) 🆓💰 - Open source LLM observability and prompt evaluation platform.
+- [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
 - [LangSmith](https://www.langchain.com/langsmith) 💰 - LangChain's platform for testing and monitoring LLM apps.
 - [Braintrust](https://www.braintrust.dev/) 💰 - LLM eval platform with experiments, datasets, and observability.
 - [Patronus AI](https://www.patronus.ai/) 💰 - Automated evaluation and security testing for LLMs.
@@ -229,6 +230,7 @@ Tools to test LLM applications themselves (security, robustness, hallucination).
 - [DeepTeam](https://github.com/confident-ai/deepteam) 🆓 - LLM red teaming for prompt injection, jailbreaks, and data leaks.
 - [llm-security-scanner](https://github.com/tugkanboz/llm-security-scanner) 🆓 - Red-team toolkit with OWASP LLM Top 10 alignment and Turkish payload library.
 - [Giskard](https://github.com/Giskard-AI/giskard) 🆓💰 - Testing framework for LLMs and ML models.
+- [Guardrails AI](https://github.com/guardrails-ai/guardrails) 🆓💰 - Python framework for validating and structuring LLM outputs using composable validators covering toxicity, PII leakage, and hallucination detection.
 - [PyRIT](https://github.com/Azure/PyRIT) 🆓 - Microsoft's Python Risk Identification Tool for generative AI.
 - [LLMFuzzer](https://github.com/mnns/LLMFuzzer) 🆓 - Early open-source fuzzing framework for testing LLMs via their API integrations. No longer actively maintained (last commit early 2024) but still referenced in LLM security lists.
 - [Lakera Guard](https://www.lakera.ai/) 💰 - Real-time prompt injection and jailbreak detection.


### PR DESCRIPTION
## What this adds

**[Opik](https://github.com/comet-ml/opik)** - added to *LLM-as-Judge Evaluation*

Opik is an open-source LLM evaluation and observability platform by Comet with 19.7k GitHub stars and daily releases (latest v2.0.64, June 15 2026). It offers automated tracing, built-in LLM-as-judge metrics (hallucination detection, RAG relevance, moderation), a pytest integration for CI pipelines, and production monitoring with online evaluation rules. Apache 2.0 licensed with a commercial managed tier.

**[Guardrails AI](https://github.com/guardrails-ai/guardrails)** - added to *LLM and AI System Testing*

Guardrails AI is an open-source Python framework with 7k stars and an active release cadence (v0.10.2, June 4 2026). It intercepts LLM inputs and outputs at runtime using composable validators from Guardrails Hub, covering toxicity, PII leakage, hallucination detection, competitor mentions, and structured output enforcement. Apache 2.0 licensed with a commercial managed service (Guardrails Pro).

## Checklist

- Both tools use AI/LLMs as a core feature, not just marketing.
- Format matches the existing entry style (linked name, badge, single sentence ending with a period, no em dashes).
- Placed in the most appropriate existing sections.
- Neither entry is a duplicate of anything currently in the list.
- Links verified as active projects with recent commits and releases.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3A3MFRzTMxLXSQ4tQYSPd)_