### PR TITLE
Add: LLM Guard and AgentBench

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Tools to test LLM applications themselves (security, robustness, hallucination).
 - [llm-security-scanner](https://github.com/tugkanboz/llm-security-scanner) 🆓 - Red-team toolkit with OWASP LLM Top 10 alignment and Turkish payload library.
 - [Giskard](https://github.com/Giskard-AI/giskard) 🆓💰 - Testing framework for LLMs and ML models.
 - [PyRIT](https://github.com/Azure/PyRIT) 🆓 - Microsoft's Python Risk Identification Tool for generative AI.
+- [LLM Guard](https://github.com/protectai/llm-guard) 🆓 - Open source security toolkit from Protect AI with scanners for prompt injection, toxicity, secrets, and data leakage in LLM inputs and outputs.
 - [LLMFuzzer](https://github.com/mnns/LLMFuzzer) 🆓 - Early open-source fuzzing framework for testing LLMs via their API integrations. No longer actively maintained (last commit early 2024) but still referenced in LLM security lists.
 - [Lakera Guard](https://www.lakera.ai/) 💰 - Real-time prompt injection and jailbreak detection.
 - [Prompt Security](https://www.prompt.security/) 💰 - Runtime prompt injection and data leak protection platform.
@@ -283,6 +284,7 @@ Learning resources for AI-powered testing.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
+- [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
Adds two genuinely notable, actively maintained projects that were missing from the list.

## LLM Guard - https://github.com/protectai/llm-guard

- Added to: **LLM and AI System Testing**
- 3.1k stars, MIT licensed, open source
- Security toolkit from Protect AI with 15 prompt scanners and 20 output scanners covering prompt injection, toxicity, secrets detection, and data leakage prevention
- Complements existing red-team tools (Garak, PyRIT) with a runtime security scanning angle

## AgentBench - https://github.com/THUDM/AgentBench

- Added to: **Benchmarks and Datasets**
- 3.5k stars, open source, published at ICLR 2024
- Evaluates LLMs as autonomous agents across eight environments: OS, database, knowledge graphs, web shopping, web browsing, house-holding, card games, and lateral thinking puzzles
- Actively updated in 2025 with a function-calling variant (AgentBench FC)

Both links were verified active before adding. Entries follow the existing format: linked name, badge, single sentence description starting with an uppercase letter and ending with a period, no em dashes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrkSdrChYRWLS39cuvXnZF)_