### PR TITLE
Add: OpenLLMetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
 - [Helicone](https://github.com/Helicone/helicone) 🆓💰 - Open source LLM observability and prompt evaluation platform.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
+- [OpenLLMetry](https://github.com/traceloop/openllmetry) 🆓 - Open-source OpenTelemetry extension that instruments LLM calls to OpenAI, Anthropic, Bedrock, and other providers, capturing traces, token usage, and latency for GenAI observability.
 - [LangSmith](https://www.langchain.com/langsmith) 💰 - LangChain's platform for testing and monitoring LLM apps.
 - [Braintrust](https://www.braintrust.dev/) 💰 - LLM eval platform with experiments, datasets, and observability.
 - [Patronus AI](https://www.patronus.ai/) 💰 - Automated evaluation and security testing for LLMs.


### PR DESCRIPTION
## What this adds

[OpenLLMetry](https://github.com/traceloop/openllmetry) by Traceloop - an open-source extension of OpenTelemetry that instruments LLM calls across 20+ providers (OpenAI, Anthropic, Bedrock, etc.) and vector databases (Pinecone, Chroma, Weaviate), capturing traces, token usage, and latency.

Added to the **LLM-as-Judge Evaluation** section, after Opik and before LangSmith, grouped with the other LLM observability tools.

## Why it belongs here

- 7.1k+ GitHub stars, Apache-2.0 license
- Actively maintained - 258 releases, latest v0.61.0 (May 2026), 1,400+ commits
- Genuinely fills a gap: the existing observability tools (Langfuse, Helicone, Opik, Arize Phoenix) are platforms; OpenLLMetry is the vendor-neutral OpenTelemetry instrumentation layer teams use to feed data into those platforms
- Widely referenced alongside the tools already listed in this section

## Checklist

- [x] Entry uses the correct format: `- [Name](link) BADGE - Description.`
- [x] Description is one sentence, starts with uppercase, ends with period
- [x] No em dashes or double hyphens
- [x] Not a duplicate
- [x] Tool has a clear AI/ML component (instruments and traces LLM calls)
- [x] Project is actively maintained (last release May 2026)