### PR TITLE
Add: OSWorld

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Learning resources for AI-powered testing.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
+- [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.
 


### PR DESCRIPTION
## What

Adds [OSWorld](https://github.com/xlang-ai/OSWorld) to the **Benchmarks and Datasets** section.

## Why

OSWorld is a NeurIPS 2024 paper and benchmark for evaluating multimodal AI agents on open-ended computer tasks in real, virtualized environments (VMware, VirtualBox, Docker, AWS). It complements the existing agent benchmarks in that section (WebArena covers web tasks; OSWorld extends coverage to the full desktop OS layer). The project has ~3k GitHub stars and is actively maintained.

## Entry added

```
- [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
```

## Checklist

- [x] Entry uses the correct badge (🆓 open source)
- [x] Description is one sentence, starts with uppercase, ends with period
- [x] No em dash or double hyphen used
- [x] Link verified as active
- [x] Not a duplicate of any existing entry
- [x] Placed in the most appropriate section in a logical position (after WebArena)