### PR TITLE
Add: NeMo Guardrails and Weights & Biases Weave

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) 🆓 - LLM evaluation framework from the UK AI Safety Institute.
 - [TruLens](https://github.com/truera/trulens) 🆓 - Evaluation framework for LLM apps with feedback functions and tracing.
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix) 🆓 - Open-source LLM observability and evaluation.
+- [Weights & Biases Weave](https://github.com/wandb/weave) 🆓💰 - Weights & Biases toolkit for tracing, debugging, and evaluating generative AI applications with built-in LLM-as-judge metrics and dataset management.
 - [OpenAI Evals](https://github.com/openai/evals) 🆓 - Framework for evaluating LLMs and an open-source registry of benchmarks from OpenAI. No longer actively maintained for new evals, but still widely used as a reference.
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) 🆓 - EleutherAI's framework for few-shot evaluation of language models, backing the Hugging Face Open LLM Leaderboard.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
@@ -232,6 +233,7 @@ Tools to test LLM applications themselves (security, robustness, hallucination).
 - [llm-security-scanner](https://github.com/tugkanboz/llm-security-scanner) 🆓 - Red-team toolkit with OWASP LLM Top 10 alignment and Turkish payload library.
 - [Giskard](https://github.com/Giskard-AI/giskard) 🆓💰 - Testing framework for LLMs and ML models.
 - [Guardrails AI](https://github.com/guardrails-ai/guardrails) 🆓💰 - Python framework for validating and structuring LLM outputs using composable validators covering toxicity, PII leakage, and hallucination detection.
+- [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) 🆓 - Open-source toolkit from NVIDIA for adding programmable guardrails to LLM-based conversational systems, preventing jailbreaks, topic drift, and unsafe outputs.
 - [PyRIT](https://github.com/Azure/PyRIT) 🆓 - Microsoft's Python Risk Identification Tool for generative AI.
 - [LLM Guard](https://github.com/protectai/llm-guard) 🆓 - Open source security toolkit from Protect AI with scanners for prompt injection, toxicity, secrets, and data leakage in LLM inputs and outputs.
 - [LLMFuzzer](https://github.com/mnns/LLMFuzzer) 🆓 - Early open-source fuzzing framework for testing LLMs via their API integrations. No longer actively maintained (last commit early 2024) but still referenced in LLM security lists.


### PR DESCRIPTION
Two notable AI testing tools not yet in the list.

## NeMo Guardrails

- **Repo:** https://github.com/NVIDIA/NeMo-Guardrails
- **Section:** LLM and AI System Testing
- **Why:** Open-source toolkit from NVIDIA for adding programmable guardrails to LLM-based conversational systems. 6.6k stars, Apache 2.0, actively maintained (latest release v0.22.0, May 2026). Directly complements Garak and Guardrails AI already in the list by covering the guardrails/safety enforcement angle.

## Weights & Biases Weave

- **Repo:** https://github.com/wandb/weave
- **Section:** LLM-as-Judge Evaluation
- **Why:** W&B's dedicated toolkit for tracing, debugging, and evaluating generative AI applications, with LLM-as-judge metrics and dataset management. Actively maintained (v0.52.43, June 2026). W&B is one of the leading MLOps platforms and Weave is widely adopted for LLM evaluation workflows.

Both links were verified as live and active before submission.