### PR TITLE
Add: Weave and EvalPlus

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
 - [Helicone](https://github.com/Helicone/helicone) 🆓💰 - Open source LLM observability and prompt evaluation platform.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
+- [Weave](https://github.com/wandb/weave) 🆓💰 - LLM evaluation and tracing toolkit from Weights & Biases with structured evaluation workflows, dataset versioning, and multi-provider tracing support.
 - [LangSmith](https://www.langchain.com/langsmith) 💰 - LangChain's platform for testing and monitoring LLM apps.
 - [Braintrust](https://www.braintrust.dev/) 💰 - LLM eval platform with experiments, datasets, and observability.
 - [Patronus AI](https://www.patronus.ai/) 💰 - Automated evaluation and security testing for LLMs.
@@ -285,6 +286,7 @@ Learning resources for AI-powered testing.
 - [BenchClaw](https://github.com/Agnuxo1/BenchClaw) 🆓 - Multi-dimension AI benchmark with 17-judge evaluation tribunal for scientific paper generation. Evaluates IMRaD structure, citation quality, methodological rigor, and reproducibility across 10 dimensions with uncertainty quantification and P2P verification.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
+- [EvalPlus](https://github.com/evalplus/evalplus) 🆓 - Rigorous code generation evaluation suite that extends HumanEval and MBPP with 80x and 35x more test cases to surface previously undetected wrong code.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.


### PR DESCRIPTION
## Summary

Two new entries for actively maintained, well-known projects not yet in the list:

### LLM-as-Judge Evaluation

- **[Weave](https://github.com/wandb/weave)** 🆓💰 - LLM evaluation and tracing toolkit from Weights & Biases (Apache-2.0, 1.1k stars, last release June 2026). Fits alongside Langfuse, Helicone, and Opik as an open-core observability and evaluation platform with structured evaluation workflows, dataset versioning, and multi-provider tracing support.

### Benchmarks and Datasets

- **[EvalPlus](https://github.com/evalplus/evalplus)** 🆓 - Rigorous code generation evaluation suite (Apache-2.0, 1.8k stars, NeurIPS 2023 and COLM 2024 papers). Extends HumanEval with 80x more test cases and MBPP with 35x more test cases, surfacing wrong code that the original benchmarks miss. Placed after HumanEval since the two are directly related.

## Checklist

- Both links resolve to active, publicly accessible GitHub repositories.
- Both projects have genuine AI/ML components as core features, not marketing.
- Descriptions are one sentence, start with an uppercase letter, end with a period, and contain no em dashes or double hyphens.
- Badges match the legend (🆓 for fully open source, 🆓💰 for open core).
- Entries are placed in the most appropriate existing sections.
- No duplicates - both were confirmed absent from the current README.