### PR TITLE
Add: MLflow and Weave to LLM-as-Judge Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,11 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix) 🆓 - Open-source LLM observability and evaluation.
 - [OpenAI Evals](https://github.com/openai/evals) 🆓 - Framework for evaluating LLMs and an open-source registry of benchmarks from OpenAI. No longer actively maintained for new evals, but still widely used as a reference.
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) 🆓 - EleutherAI's framework for few-shot evaluation of language models, backing the Hugging Face Open LLM Leaderboard.
+- [MLflow](https://github.com/mlflow/mlflow) 🆓 - Widely adopted open-source AI engineering platform with GenAI evaluation, LLM-as-judge metrics, and experiment tracking via mlflow.genai.evaluate().
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
 - [Helicone](https://github.com/Helicone/helicone) 🆓💰 - Open source LLM observability and prompt evaluation platform.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
+- [Weave](https://github.com/wandb/weave) 🆓💰 - Weights & Biases toolkit for tracing LLM calls, running systematic evaluations, and iterating on generative AI applications in production.
 - [LangSmith](https://www.langchain.com/langsmith) 💰 - LangChain's platform for testing and monitoring LLM apps.
 - [Braintrust](https://www.braintrust.dev/) 💰 - LLM eval platform with experiments, datasets, and observability.
 - [Patronus AI](https://www.patronus.ai/) 💰 - Automated evaluation and security testing for LLMs.


### PR DESCRIPTION
## What

Adds two widely used, actively maintained open-source tools to the **LLM-as-Judge Evaluation** section:

- **[MLflow](https://github.com/mlflow/mlflow)** 🆓 - Apache-2.0, 26.8k stars, latest release v3.14.0 (June 17, 2026). MLflow's `mlflow.genai.evaluate()` provides built-in LLM-as-judge scoring, 50+ GenAI quality metrics, and side-by-side model comparison. It is the most widely used open-source ML experiment tracking platform and has matured into a full AI engineering platform with strong LLM evaluation capabilities.

- **[Weave](https://github.com/wandb/weave)** 🆓💰 - Apache-2.0, 1.1k stars, latest release v0.52.43 (June 15, 2026). Weights & Biases' purpose-built toolkit for tracing LLM calls, running systematic evaluations, and iterating on generative AI applications. It sits naturally alongside Langfuse, Opik, and Helicone already in this section.

## Placement

Both entries are inserted in the existing open-source/open-core block of the section, consistent with the ordering of similar tools already present.

## Checklist

- Both links verified as active GitHub repositories with commits in 2026.
- Descriptions are one sentence, start with an uppercase letter, and end with a period.
- No em dashes or double hyphens used.
- No duplicate entries - neither tool appears anywhere in the current README.
- Badges match the open-source/open-core model of each tool.
- Entry format matches the existing style in the section.