### PR TITLE
Add: Aider and OSWorld

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Tools that generate test cases from code, requirements, or user behavior using A
 - [GitHub Copilot](https://github.com/features/copilot) 💰 - AI pair programmer that generates test code in Playwright, Cypress, Selenium across editors.
 - [Cursor](https://www.cursor.com/) 💰 - AI-first code editor with strong test generation capabilities for major frameworks.
 - [Claude Code](https://www.anthropic.com/claude-code) 💰 - Anthropic's terminal-based agentic coding assistant, useful for test suite generation and refactoring.
+- [Aider](https://github.com/Aider-AI/aider) 🆓 - AI pair programming tool for the terminal that edits code with LLMs, auto-runs your test suite on every change, and automatically fixes linter and test failures.
 
 ## MCP-Based Testing
 
@@ -288,6 +289,7 @@ Learning resources for AI-powered testing.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.
+- [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, covering web browsers, desktop apps, and coding tools.
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
## What's added

**[Aider](https://github.com/Aider-AI/aider)** - added to Test Generation

Aider is a terminal-based AI pair programming tool with 46.9k GitHub stars. It edits codebases with LLMs and auto-runs your test suite after every change, automatically fixing linter and test failures. It is open source, actively maintained (v0.86.0 released August 2025), and widely used alongside other AI coding assistants for AI-assisted test writing. It fits the Test Generation section alongside the other general AI coding assistants already listed.

**[OSWorld](https://github.com/xlang-ai/OSWorld)** - added to Benchmarks and Datasets

OSWorld is a NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks across real computer environments including web browsers, desktop apps, and coding tools. It has 3k GitHub stars, is actively maintained, and is the natural desktop-environment companion to the already-listed WebArena (web) and AgentBench (multi-environment) benchmarks.

## Checklist

- Both links verified as resolving to active, maintained projects.
- Descriptions are one sentence, start with an uppercase letter, end with a period, and use no em dashes.
- Entries placed in the most appropriate existing sections, consistent with surrounding format and ordering.
- No duplicates introduced.