### PR TITLE
Fix duplicate Podium MCP entry breaking awesome-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ End-to-end testing platforms with AI at the core.
 - [Katalon Studio](https://katalon.com/) 🆓💰 - Test automation platform with AI features including TrueTest and Visual Testing.
 
 ## Mobile AI Testing
-- [Podium MCP](https://github.com/hoainho/podium-mcp) 🆓 - Mobile app testing MCP server for Android/iOS simulators via Maestro, with Redux state debugging and CI integration.
 
 AI-powered tools specifically for mobile app testing.
 


### PR DESCRIPTION
@
Podium MCP was listed twice: once under MCP-Based Testing and once under Mobile AI Testing. The duplicate link caused awesome-lint to fail (remark-lint:double-link) on main and on every open pull request branched from it.

This keeps the entry under MCP-Based Testing (the more detailed description) and removes the duplicate from Mobile AI Testing, which also restores the correct section structure (intro paragraph now follows the heading).
@