### PR TITLE
Add: prufa-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Tools and servers that use the Model Context Protocol to give AI agents browser 
 - [Browser MCP](https://github.com/browsermcp/mcp) 🆓 - Popular MCP server that automates the user's own local browser, preserving logged-in sessions and avoiding bot detection. Note: limited maintenance activity since mid-2025 but widely used (6.5k+ stars).
 - [Podium MCP](https://github.com/hoainho/podium-mcp) 🆓 - MCP server purpose-built for mobile app testing on Android/iOS simulators using Maestro, with deep Redux state inspection and CI pipeline integration.
 - [Puppeteer MCP](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/puppeteer) 🆓 - Reference MCP server for Puppeteer-based browser automation from the official MCP servers repo.
+- [prufa-mcp](https://github.com/prufa-dev/prufa-mcp) 🆓💰 - MCP server that lets an AI agent audit a web app (analytics, broken flows, security headers, accessibility) and get back machine-verified findings.
 
 ## Self-Healing Test Frameworks
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Tools and servers that use the Model Context Protocol to give AI agents browser 
 - [Browser MCP](https://github.com/browsermcp/mcp) 🆓 - Popular MCP server that automates the user's own local browser, preserving logged-in sessions and avoiding bot detection. Note: limited maintenance activity since mid-2025 but widely used (6.5k+ stars).
 - [Podium MCP](https://github.com/hoainho/podium-mcp) 🆓 - MCP server purpose-built for mobile app testing on Android/iOS simulators using Maestro, with deep Redux state inspection and CI pipeline integration.
 - [Puppeteer MCP](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/puppeteer) 🆓 - Reference MCP server for Puppeteer-based browser automation from the official MCP servers repo.
-- [prufa-mcp](https://github.com/prufa-dev/prufa-mcp) 🆓💰 - MCP server that lets an AI agent audit a web app (analytics, broken flows, security headers, accessibility) and get back machine-verified findings.
+- [prufa-mcp](https://github.com/prufa-dev/prufa-mcp) 🆓💰 - Open-source (Apache-2.0) MCP server connected to Prufa's hosted audit backend; an AI agent runs a QA audit of a web app (analytics, broken flows, security headers, accessibility) and gets back machine-verified findings. First audit is free; further audits and features require a paid plan.
 
 ## Self-Healing Test Frameworks
 


### PR DESCRIPTION
Adds prufa-mcp to the MCP-Based Testing section.

prufa-mcp is an open-source (Apache-2.0) MCP server that lets an AI agent run a QA audit of a web app — checking analytics/tracking, broken flows, security headers, and accessibility — and get back machine-verified findings. The heavy work runs server-side; the audit result is returned as structured JSON to the agent.

It's open source and free to try: the first audit requires no card. Repo: https://github.com/prufa-dev/prufa-mcp