### PR TITLE
Add: Evidently AI and AgentDojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
 - [Helicone](https://github.com/Helicone/helicone) 🆓💰 - Open source LLM observability and prompt evaluation platform.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
+- [Evidently AI](https://github.com/evidentlyai/evidently) 🆓💰 - Open-source Python framework for testing, evaluating, and monitoring ML and LLM systems with 100+ built-in metrics covering drift detection, text quality, and LLM response evaluation.
 - [LangSmith](https://www.langchain.com/langsmith) 💰 - LangChain's platform for testing and monitoring LLM apps.
 - [Braintrust](https://www.braintrust.dev/) 💰 - LLM eval platform with experiments, datasets, and observability.
 - [Patronus AI](https://www.patronus.ai/) 💰 - Automated evaluation and security testing for LLMs.
@@ -230,6 +231,7 @@ Tools to test LLM applications themselves (security, robustness, hallucination).
 
 - [Garak](https://github.com/NVIDIA/garak) 🆓 - LLM vulnerability scanner from NVIDIA.
 - [DeepTeam](https://github.com/confident-ai/deepteam) 🆓 - LLM red teaming for prompt injection, jailbreaks, and data leaks.
+- [AgentDojo](https://github.com/ethz-spylab/agentdojo) 🆓 - NeurIPS 2024 dynamic benchmark from ETH Zurich for evaluating prompt injection attacks and defenses against LLM agents across 97 tasks and 629 security test cases.
 - [llm-security-scanner](https://github.com/tugkanboz/llm-security-scanner) 🆓 - Red-team toolkit with OWASP LLM Top 10 alignment and Turkish payload library.
 - [Giskard](https://github.com/Giskard-AI/giskard) 🆓💰 - Testing framework for LLMs and ML models.
 - [Guardrails AI](https://github.com/guardrails-ai/guardrails) 🆓💰 - Python framework for validating and structuring LLM outputs using composable validators covering toxicity, PII leakage, and hallucination detection.


### PR DESCRIPTION
## What

Adds two new entries:

**[Evidently AI](https://github.com/evidentlyai/evidently)** - added to **LLM-as-Judge Evaluation**

An open-source Python framework for testing, evaluating, and monitoring ML and LLM systems. 7.7k GitHub stars, actively maintained (latest release v0.7.21, March 2026). Provides 100+ built-in metrics covering data drift, LLM quality scoring, text evaluation (sentiment, toxicity, semantic similarity), and a production monitoring dashboard. Apache 2.0 with a managed cloud tier, so 🆓💰.

**[AgentDojo](https://github.com/ethz-spylab/agentdojo)** - added to **LLM and AI System Testing**

A dynamic benchmark from ETH Zurich for evaluating prompt injection attacks and defenses against LLM agents. Introduced at NeurIPS 2024. Covers 97 realistic user tasks and 629 security test cases across email, banking, travel, and workspace domains. Actively maintained (v0.1.35, October 2025). Pure open source, so 🆓.

## Checklist

- Both links resolve to active, public GitHub repositories
- Neither project is already listed in the README
- Both have genuine AI/ML as a core feature, not marketing
- Descriptions are one sentence, start with an uppercase letter, end with a period, and contain no em dashes or double hyphens
- Entries are placed in the most appropriate existing sections
- Ordering within each section is consistent with surrounding entries
- Format matches the existing `- [Name](link) BADGE - Description.` style

---
_Generated by [Claude Code](https://claude.ai/code/session_014xA6MibRjzw2qmhxpHp4FS)_