### PR TITLE
Add: LangWatch and Momentic

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ End-to-end testing platforms with AI at the core.
 - [Octomind](https://www.octomind.dev/) 💰 - Auto-generated, run, and maintained Playwright tests with AI test case discovery.
 - [Mabl](https://www.mabl.com/) 💰 - Low-code platform with auto-healing and ML-based test maintenance.
 - [Meticulous](https://www.meticulous.ai/) 💰 - Records real user sessions and generates regression tests automatically.
+- [Momentic](https://momentic.ai/) 💰 - AI-native end-to-end testing platform that writes, runs, and maintains web and mobile tests automatically using natural language.
 - [Autify](https://autify.com/) 💰 - No-code end-to-end testing platform with AI-driven maintenance.
 - [Reflect](https://reflect.run/) 💰 - No-code regression testing with AI-assisted authoring.
 - [QA Wolf](https://www.qawolf.com/) 💰 - AI-powered QA-as-a-service generating Playwright tests at scale.
@@ -150,6 +151,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
 - [Helicone](https://github.com/Helicone/helicone) 🆓💰 - Open source LLM observability and prompt evaluation platform.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
+- [LangWatch](https://github.com/langwatch/langwatch) 🆓💰 - Open-source LLM evaluation and AI agent testing platform combining end-to-end scenario simulation, observability, and prompt management in a single unified loop.
 - [LangSmith](https://www.langchain.com/langsmith) 💰 - LangChain's platform for testing and monitoring LLM apps.
 - [Braintrust](https://www.braintrust.dev/) 💰 - LLM eval platform with experiments, datasets, and observability.
 - [Patronus AI](https://www.patronus.ai/) 💰 - Automated evaluation and security testing for LLMs.


### PR DESCRIPTION
## Summary

Two new entries for well-known, actively maintained AI testing tools not yet listed in the repository.

### LangWatch - LLM-as-Judge Evaluation

- **Repo:** https://github.com/langwatch/langwatch
- **Stars:** 3.3k
- **License:** Apache 2.0 (core) / MIT (SDKs); enterprise modules are commercial
- **Last release:** langwatch-3.5.0, June 29, 2026
- **Why it belongs:** Open-source platform for LLM evaluation and AI agent testing combining scenario simulation, observability tracing, and prompt management in one workflow. Meaningfully distinct from Langfuse and Helicone through its focus on agent scenario simulation and OpenTelemetry-native architecture.

### Momentic - AI-Powered E2E Platforms

- **Site:** https://momentic.ai/
- **Backing:** Y Combinator; $15M Series A (Standard Capital, Dropbox Ventures)
- **License:** Commercial (SDKs open-source under MIT/ISC)
- **Why it belongs:** AI-native end-to-end testing platform for web and mobile using natural language. Well-known in the testing community and a natural companion to the other commercial E2E platforms already listed (Mabl, Meticulous, QA Wolf, etc.).

## Checklist

- Entries use the correct `- [Name](link) BADGE - Description.` format
- Badges are correct (🆓💰 for LangWatch, 💰 for Momentic)
- Descriptions start with an uppercase letter and end with a period
- No em dashes or double hyphens used
- Both links verified as live, active projects
- No duplicates - neither tool appears anywhere in the current README
- Placed in the most appropriate existing section, consistent with surrounding order

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJ1gqKZiQdz2ViUJjymegb)_