### PR TITLE
Add: BrowserGym

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Learning resources for AI-powered testing.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.
+- [BrowserGym](https://github.com/ServiceNow/BrowserGym) 🆓 - ServiceNow's gym environment for web agent research that consolidates multiple benchmarks including WebArena, VisualWebArena, and MiniWoB under a single standardized Gymnasium interface.
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
Adds [BrowserGym](https://github.com/ServiceNow/BrowserGym) to the **Benchmarks and Datasets** section.

## About the project

BrowserGym is an open-source Gymnasium-based framework from ServiceNow for web agent research. It consolidates multiple web agent benchmarks under a single standardized environment, making it easy to evaluate agents across different task suites without custom integration work for each one.

- **GitHub:** https://github.com/ServiceNow/BrowserGym
- **License:** Apache 2.0
- **Stars:** 1.3k
- **Latest release:** v0.14.3 (January 20, 2026), actively maintained with 59 total releases

**Benchmarks unified:**
- MiniWoB (100+ synthetic web tasks)
- WebArena and WebArenaVerified (realistic self-hosted domain tasks)
- VisualWebArena (visual-focused web tasks)
- WorkArena (ServiceNow platform tasks)
- AssistantBench and others

## Why it belongs here

The Benchmarks and Datasets section already includes several web and agent-focused entries (WebArena, AgentBench, OSWorld, tau-bench). BrowserGym is the natural complement as a unified harness that runs all of those web-task benchmarks from a single interface - it is widely used in academic web agent research and is not currently listed.

## Checklist

- Entry is not a duplicate - confirmed absent from the current README and all open PRs
- Link resolves to an active, publicly accessible GitHub repository
- Format matches existing entries: `[Name](url) 🆓 - One sentence.`
- Description is one sentence, starts with an uppercase letter, ends with a period
- No em dashes or double hyphens used
- Placed after AgentBench, consistent with the section's ordering

---
_Generated by [Claude Code](https://claude.ai/code/session_01T14gnBtExsh8zJKNHwH25B)_