### PR TITLE
Add: Evidently and LiveBench

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) 🆓 - LLM evaluation framework from the UK AI Safety Institute.
 - [TruLens](https://github.com/truera/trulens) 🆓 - Evaluation framework for LLM apps with feedback functions and tracing.
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix) 🆓 - Open-source LLM observability and evaluation.
+- [Evidently](https://github.com/evidentlyai/evidently) 🆓 - Open-source framework to evaluate, test, and monitor ML and LLM systems with 100+ built-in metrics and LLM-as-judge support.
 - [Weights & Biases Weave](https://github.com/wandb/weave) 🆓💰 - Weights & Biases toolkit for tracing, debugging, and evaluating generative AI applications with built-in LLM-as-judge metrics and dataset management.
 - [OpenAI Evals](https://github.com/openai/evals) 🆓 - Framework for evaluating LLMs and an open-source registry of benchmarks from OpenAI. No longer actively maintained for new evals, but still widely used as a reference.
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) 🆓 - EleutherAI's framework for few-shot evaluation of language models, backing the Hugging Face Open LLM Leaderboard.
@@ -293,6 +294,7 @@ Learning resources for AI-powered testing.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.
+- [LiveBench](https://github.com/LiveBench/LiveBench) 🆓 - Contamination-resistant LLM benchmark with 18 diverse tasks across 6 categories that refreshes questions monthly using recently released papers and news.
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
Two new entries for well-known, actively maintained projects not yet listed.

## Evidently - LLM-as-Judge Evaluation

- **Repo:** https://github.com/evidentlyai/evidently
- **Stars:** 7.7k
- **Last release:** v0.7.21 (March 2026)
- **Why it belongs:** Open-source Python framework for evaluating, testing, and monitoring ML and LLM systems. Provides 100+ built-in metrics, LLM-as-judge evaluators, semantic similarity checks, retrieval relevance scoring, and CI-ready test suites - a direct fit for the LLM-as-Judge Evaluation section.

## LiveBench - Benchmarks and Datasets

- **Repo:** https://github.com/LiveBench/LiveBench
- **Stars:** 1.2k
- **Spotlight Paper:** ICLR 2025
- **Why it belongs:** Contamination-resistant LLM benchmark that refreshes its 18 tasks across 6 categories monthly using recently released arXiv papers, news, and datasets. Uses objective, automatically-scorable answers with no LLM judge needed - a useful complement to the existing benchmark entries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4sx2rWkeQdtPQrxNXE1Gn)_