### PR TITLE
Add: PurpleLlama

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Tools to test LLM applications themselves (security, robustness, hallucination).
 - [Giskard](https://github.com/Giskard-AI/giskard) 🆓💰 - Testing framework for LLMs and ML models.
 - [Guardrails AI](https://github.com/guardrails-ai/guardrails) 🆓💰 - Python framework for validating and structuring LLM outputs using composable validators covering toxicity, PII leakage, and hallucination detection.
 - [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) 🆓 - Open-source toolkit from NVIDIA for adding programmable guardrails to LLM-based conversational systems, preventing jailbreaks, topic drift, and unsafe outputs.
+- [PurpleLlama](https://github.com/meta-llama/PurpleLlama) 🆓 - Meta's open-source toolkit for assessing and improving LLM security, including Llama Guard for safety classification and CyberSecEval for cybersecurity risk benchmarking.
 - [PyRIT](https://github.com/Azure/PyRIT) 🆓 - Microsoft's Python Risk Identification Tool for generative AI.
 - [LLM Guard](https://github.com/protectai/llm-guard) 🆓 - Open source security toolkit from Protect AI with scanners for prompt injection, toxicity, secrets, and data leakage in LLM inputs and outputs.
 - [LLMFuzzer](https://github.com/mnns/LLMFuzzer) 🆓 - Early open-source fuzzing framework for testing LLMs via their API integrations. No longer actively maintained (last commit early 2024) but still referenced in LLM security lists.


### PR DESCRIPTION
Adds [PurpleLlama](https://github.com/meta-llama/PurpleLlama) to the **LLM and AI System Testing** section.

## What is PurpleLlama?

PurpleLlama is Meta's open-source umbrella project for tools and benchmarks aimed at assessing and improving LLM security. It ships two main components:

- **Llama Guard** - an instruction-tuned model for classifying LLM inputs and outputs as safe or unsafe across multiple harm categories (versions up to Llama Guard 4 and Llama-Prompt-Guard-2 are included).
- **CyberSecEval** - a benchmark suite (currently at v4) measuring both the cybersecurity vulnerabilities of LLMs and their defensive capabilities, including insecure code generation, cyberattack assistance, SOC automation, and automated vulnerability patching.

## Why include it?

- 4.3k GitHub stars, actively maintained by Meta with 469 commits and ongoing pull requests.
- Directly relevant to the section goal: "tools to test LLM applications themselves (security, robustness, hallucination)."
- Fills a gap - existing entries cover NVIDIA (Garak, NeMo Guardrails), Microsoft (PyRIT), and Protect AI (LLM Guard), but not Meta's equivalent offering.
- All components are permissively licensed (MIT for evals/benchmarks, Llama Community License for models).

## Checklist

- Entry follows the `- [Name](link) BADGE - Description.` format.
- Badge is 🆓 (open source).
- Description is one sentence, starts with uppercase, ends with a period, contains no em dashes.
- Placed after NeMo Guardrails (NVIDIA) and before PyRIT (Microsoft) to keep big-company security toolkits grouped together.
- Link verified active.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8YVa5Awi54A5Qs8BTRUYr)_