### PR TITLE
Add: Purple Llama

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Tools to test LLM applications themselves (security, robustness, hallucination).
 - [Guardrails AI](https://github.com/guardrails-ai/guardrails) 🆓💰 - Python framework for validating and structuring LLM outputs using composable validators covering toxicity, PII leakage, and hallucination detection.
 - [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) 🆓 - Open-source toolkit from NVIDIA for adding programmable guardrails to LLM-based conversational systems, preventing jailbreaks, topic drift, and unsafe outputs.
 - [PyRIT](https://github.com/Azure/PyRIT) 🆓 - Microsoft's Python Risk Identification Tool for generative AI.
+- [Purple Llama](https://github.com/meta-llama/PurpleLlama) 🆓 - Meta's open-source toolkit for evaluating LLM security risks, including the CyberSecEval benchmark suite for insecure code generation and cyberattack compliance testing.
 - [LLM Guard](https://github.com/protectai/llm-guard) 🆓 - Open source security toolkit from Protect AI with scanners for prompt injection, toxicity, secrets, and data leakage in LLM inputs and outputs.
 - [LLMFuzzer](https://github.com/mnns/LLMFuzzer) 🆓 - Early open-source fuzzing framework for testing LLMs via their API integrations. No longer actively maintained (last commit early 2024) but still referenced in LLM security lists.
 - [Lakera Guard](https://www.lakera.ai/) 💰 - Real-time prompt injection and jailbreak detection.


### PR DESCRIPTION
## What this adds

[Purple Llama](https://github.com/meta-llama/PurpleLlama) to the **LLM and AI System Testing** section.

## Why it belongs here

Purple Llama is Meta's open-source umbrella project for evaluating and improving LLM security. Its flagship component, **CyberSecEval** (now on v4), provides structured benchmarks that measure:

- Insecure code generation propensity (aligned with CWE and MITRE ATT&CK)
- Cyberattack compliance (MITRE and False Refusal Rate tests)
- Prompt injection susceptibility (text and visual)
- Autonomous offensive cyber operations
- Automatic vulnerability patching (AutoPatchBench, added in v4 in collaboration with CrowdStrike)

CyberSecEval 4 has been applied to Llama 4 as well as models from OpenAI, Google, and Anthropic, making it a widely recognised industry benchmark rather than a niche internal tool.

## Checklist

- Genuine AI/ML core feature - yes (security evaluation via LLM analysis and automated benchmarking)
- Format matches existing entries - yes (`- [Name](link) 🆓 - Description.`)
- One-sentence description, starts uppercase, ends with period - yes
- No em dash, no double hyphen - yes
- Not a duplicate - confirmed via full README search
- Link verified active - yes (4.3k stars, 469+ commits, CyberSecEval 4 published 2025)
- Placed in most appropriate section - yes (alongside PyRIT/Microsoft and Garak/NVIDIA)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BTy597wzvz3LVevhQQ3tne)_