### PR TITLE
Add: LightEval and MTEB

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Weights & Biases Weave](https://github.com/wandb/weave) 🆓💰 - Weights & Biases toolkit for tracing, debugging, and evaluating generative AI applications with built-in LLM-as-judge metrics and dataset management.
 - [OpenAI Evals](https://github.com/openai/evals) 🆓 - Framework for evaluating LLMs and an open-source registry of benchmarks from OpenAI. No longer actively maintained for new evals, but still widely used as a reference.
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) 🆓 - EleutherAI's framework for few-shot evaluation of language models, backing the Hugging Face Open LLM Leaderboard.
+- [LightEval](https://github.com/huggingface/lighteval) 🆓 - Hugging Face's lightweight LLM evaluation toolkit supporting 1,000+ tasks across knowledge, math, coding, and reasoning with multiple model serving backends.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
 - [Helicone](https://github.com/Helicone/helicone) 🆓💰 - Open source LLM observability and prompt evaluation platform.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
@@ -310,6 +311,7 @@ Learning resources for AI-powered testing.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.
+- [MTEB](https://github.com/embeddings-benchmark/mteb) 🆓 - Massive text embedding benchmark covering retrieval, clustering, classification, and semantic similarity tasks across 250+ datasets and 112 languages.
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
Adds two well-maintained, widely used open-source tools that were missing from the list.

**LightEval** ([huggingface/lighteval](https://github.com/huggingface/lighteval)) - added to **LLM-as-Judge Evaluation**
- 2.5k stars, last release November 2025
- Hugging Face's evaluation toolkit for LLMs, supporting 1,000+ tasks (knowledge, math, coding, reasoning) with multiple model serving backends (vLLM, TGI, nanotron)
- Complements the existing lm-evaluation-harness entry; its focus is on rapid, flexible evaluation during model development across different serving stacks

**MTEB** ([embeddings-benchmark/mteb](https://github.com/embeddings-benchmark/mteb)) - added to **Benchmarks and Datasets**
- 3.4k stars, last release July 2026 (actively maintained)
- The standard benchmark for evaluating text and multimodal embedding models across retrieval, clustering, classification, and semantic similarity, spanning 250+ datasets and 112 languages
- Widely used by AI teams evaluating embedding models for RAG and semantic search applications

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPHRPExvm8jTXbXT7M6h3A)_