### PR TITLE
Add: MLflow and VisualWebArena

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [TruLens](https://github.com/truera/trulens) 🆓 - Evaluation framework for LLM apps with feedback functions and tracing.
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix) 🆓 - Open-source LLM observability and evaluation.
 - [Weights & Biases Weave](https://github.com/wandb/weave) 🆓💰 - Weights & Biases toolkit for tracing, debugging, and evaluating generative AI applications with built-in LLM-as-judge metrics and dataset management.
+- [MLflow](https://github.com/mlflow/mlflow) 🆓💰 - Open source AI engineering platform for evaluating, tracing, and monitoring LLM applications and agents with 50+ built-in LLM-as-judge scorers covering correctness, relevance, groundedness, and safety.
 - [OpenAI Evals](https://github.com/openai/evals) 🆓 - Framework for evaluating LLMs and an open-source registry of benchmarks from OpenAI. No longer actively maintained for new evals, but still widely used as a reference.
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) 🆓 - EleutherAI's framework for few-shot evaluation of language models, backing the Hugging Face Open LLM Leaderboard.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
@@ -307,6 +308,7 @@ Learning resources for AI-powered testing.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
+- [VisualWebArena](https://github.com/web-arena-x/visualwebarena) - ACL 2024 benchmark for evaluating multimodal web agents on 910 tasks across three web environments, extending WebArena with visual reasoning over image-text inputs.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.


### PR DESCRIPTION
## MLflow - LLM-as-Judge Evaluation

[MLflow](https://github.com/mlflow/mlflow) is an open source AI engineering platform backed by the Linux Foundation with 26k+ GitHub stars. It provides 50+ built-in LLM-as-judge scorers for evaluating correctness, relevance, groundedness, and safety in LLM applications and agents. It supports multiple LLM providers (OpenAI, Anthropic, Amazon Bedrock, Mistral) as judges and pairs them with full experiment tracking, tracing, and production monitoring. Added to the **LLM-as-Judge Evaluation** section after Weights & Biases Weave, which has a similar profile as a major ML platform with LLM eval features.

## VisualWebArena - Benchmarks and Datasets

[VisualWebArena](https://github.com/web-arena-x/visualwebarena) is a benchmark published at ACL 2024 for evaluating multimodal web agents. It extends the already-listed WebArena with visual reasoning tasks - 910 tasks across three web environments (Classifieds, Shopping, Reddit) that test image-text comprehension, spatial reasoning, and visual decision-making. Top-performing agents reach only 16.4% success rate vs. 88.7% for humans, making it a genuinely challenging and well-cited reference for multimodal agent evaluation. Added to the **Benchmarks and Datasets** section immediately after WebArena.

---
_Generated by [Claude Code](https://claude.ai/code/session_012qFejZrcxp9qPk7ekxbhMQ)_