### PR TITLE
Add: Kane CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Browser automation libraries designed for or commonly used by AI agents.
 - [Lightpanda](https://github.com/lightpanda-io/browser) 🆓 - Headless browser written in Zig, optimized for AI agents and scraping workloads.
 - [AgentQL](https://github.com/tinyfish-io/agentql) 🆓💰 - Natural language query language for AI agents to interact with and extract structured data from web pages, with self-healing selectors that integrate with Playwright.
 - [Browserbase](https://www.browserbase.com/) 💰 - Cloud browser infrastructure with natural language automation.
+- [Kane CLI](https://www.testmuai.com/kane-cli/) 🆓💰 - Runs browser tests from natural-language objectives and returns structured pass/fail results, so coding agents (Claude Code, Cursor, Codex CLI, Gemini CLI) can verify their own changes in a real browser.
 
 ## Articles and Talks
 


### PR DESCRIPTION
Adds [Kane CLI](https://www.testmuai.com/kane-cli/) to the Browser Automation for AI Agents section. It's a CLI that coding agents like Claude Code, Cursor, Codex CLI, and Gemini CLI install as a skill to run browser tests from natural-language objectives and get structured pass/fail back, so an agent can verify its own changes actually work in a real browser. Followed the entry format and badge legend, and placed it at the end of the section since it's a newer tool. Disclosure: I work on Kane CLI at TestMu AI — happy to answer questions here or at sparshk@testmuai.com.