### PR TITLE
Add: EvalPlus

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Learning resources for AI-powered testing.
 - [HELM](https://github.com/stanford-crfm/helm) 🆓 - Stanford CRFM's open-source Python framework for holistic, reproducible, and transparent evaluation of LLMs and multimodal models across dozens of scenarios covering accuracy, robustness, efficiency, bias, and safety.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
+- [EvalPlus](https://github.com/evalplus/evalplus) 🆓 - Rigorous code generation benchmark extending HumanEval and MBPP with 80x and 35x more LLM-generated test cases, adopted by Meta, Qwen, and DeepSeek for evaluating their coding models.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.


### PR DESCRIPTION
Adds [EvalPlus](https://github.com/evalplus/evalplus) to the **Benchmarks and Datasets** section, placed directly after HumanEval since EvalPlus extends it.

## What is EvalPlus?

EvalPlus is a rigorous code generation evaluation framework that extends both HumanEval and MBPP with substantially larger, automatically generated test suites - 80x more tests for HumanEval and 35x more for MBPP. It also includes EvalPerf for code efficiency evaluation. The project has been adopted by major AI labs including Meta (Llama 3.1/3.3), Alibaba Qwen, DeepSeek, and Allen AI (TULU) for benchmarking their code generation models.

- GitHub: https://github.com/evalplus/evalplus
- License: Apache-2.0 (🆓)
- Stars: ~1.8k
- Papers: NeurIPS 2023, COLM 2024

## Why add it?

HumanEval is already listed in the Benchmarks section. EvalPlus is the de facto standard extension of HumanEval used by the community to reduce false-positive pass rates from weak original tests - a natural and notable complement to the existing entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxztEFXBCb7iMmnh2EuqvW)_