### PR TITLE
Add: MLflow and AgentOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Weights & Biases Weave](https://github.com/wandb/weave) 🆓💰 - Weights & Biases toolkit for tracing, debugging, and evaluating generative AI applications with built-in LLM-as-judge metrics and dataset management.
 - [OpenAI Evals](https://github.com/openai/evals) 🆓 - Framework for evaluating LLMs and an open-source registry of benchmarks from OpenAI. No longer actively maintained for new evals, but still widely used as a reference.
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) 🆓 - EleutherAI's framework for few-shot evaluation of language models, backing the Hugging Face Open LLM Leaderboard.
+- [MLflow](https://github.com/mlflow/mlflow) 🆓 - Open-source AI engineering platform with built-in LLM-as-judge scorers, agent tracing via OpenTelemetry, and experiment tracking for iterative prompt and model evaluation.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
 - [Helicone](https://github.com/Helicone/helicone) 🆓💰 - Open source LLM observability and prompt evaluation platform.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
@@ -257,6 +258,7 @@ Tools to test LLM applications themselves (security, robustness, hallucination).
 - [LLMFuzzer](https://github.com/mnns/LLMFuzzer) 🆓 - Early open-source fuzzing framework for testing LLMs via their API integrations. No longer actively maintained (last commit early 2024) but still referenced in LLM security lists.
 - [Lakera Guard](https://www.lakera.ai/) 💰 - Real-time prompt injection and jailbreak detection.
 - [Prompt Security](https://www.prompt.security/) 💰 - Runtime prompt injection and data leak protection platform.
+- [AgentOps](https://github.com/AgentOps-AI/agentops) 🆓💰 - Python SDK for AI agent observability and testing with session replay, cost tracking, LLM call tracing, and multi-agent framework support for CrewAI, Langchain, and Autogen.
 - [WhyLabs](https://whylabs.ai/) 💰 - ML observability and LLM monitoring.
 - [Confident AI](https://www.confident-ai.com/) 💰 - LLM testing platform built around DeepEval.
 


### PR DESCRIPTION
Adds two actively maintained, widely adopted tools that were missing from the list.

## MLflow - LLM-as-Judge Evaluation

- **Link:** https://github.com/mlflow/mlflow
- **Badge:** 🆓 (Apache 2.0)
- **Why:** MLflow is the industry's most widely used open-source AI engineering platform (30M+ monthly downloads) and has built comprehensive LLM and agent evaluation features, including 50+ built-in LLM-as-judge scorers, OpenTelemetry-based agent tracing, and CI/CD integration. It was missing from the list despite being a natural complement to the other evaluation frameworks already there.
- **Placement:** After `lm-evaluation-harness` in the LLM-as-Judge Evaluation section (consistent with open-source-first ordering).

## AgentOps - LLM and AI System Testing

- **Link:** https://github.com/AgentOps-AI/agentops
- **Badge:** 🆓💰 (MIT SDK + commercial platform)
- **Why:** AgentOps has 5.6k stars, was last updated June 2026, and is a go-to SDK for testing and debugging AI agents - covering session replay, cost tracking, LLM call tracing, and failure detection across CrewAI, Langchain, Autogen, and the OpenAI Agents SDK.
- **Placement:** Before `WhyLabs` in the LLM and AI System Testing section (grouped with monitoring and observability tools for AI systems).

Both entries follow the existing format exactly: linked name, badge, single sentence description starting with uppercase and ending with a period, no em dashes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk6zgrCWgV4wVH7e3yWaCV)_