### PR TITLE
Add: MLflow and MTEB

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
 - [LangWatch](https://github.com/langwatch/langwatch) 🆓💰 - Open-source LLM evaluation and AI agent testing platform combining end-to-end scenario simulation, observability, and prompt management in a single unified loop.
 - [Evidently](https://github.com/evidentlyai/evidently) 🆓💰 - Open-source Python library for evaluating, testing, and monitoring ML and LLM systems with 100+ built-in metrics for data quality, drift detection, and LLM output quality.
+- [MLflow](https://github.com/mlflow/mlflow) 🆓💰 - Open-source AI engineering platform with LLM evaluation, 50+ built-in judge metrics, experiment tracking, and pytest integration for testing agents, RAG pipelines, and generative AI applications.
 - [LangSmith](https://www.langchain.com/langsmith) 💰 - LangChain's platform for testing and monitoring LLM apps.
 - [Braintrust](https://www.braintrust.dev/) 💰 - LLM eval platform with experiments, datasets, and observability.
 - [Patronus AI](https://www.patronus.ai/) 💰 - Automated evaluation and security testing for LLMs.
@@ -292,6 +293,7 @@ Learning resources for AI-powered testing.
 
 - [BenchClaw](https://github.com/Agnuxo1/BenchClaw) 🆓 - Multi-dimension AI benchmark with 17-judge evaluation tribunal for scientific paper generation. Evaluates IMRaD structure, citation quality, methodological rigor, and reproducibility across 10 dimensions with uncertainty quantification and P2P verification.
 - [HELM](https://github.com/stanford-crfm/helm) 🆓 - Stanford CRFM's open-source Python framework for holistic, reproducible, and transparent evaluation of LLMs and multimodal models across dozens of scenarios covering accuracy, robustness, efficiency, bias, and safety.
+- [MTEB](https://github.com/embeddings-benchmark/mteb) 🆓 - Community benchmark and leaderboard for evaluating text and multimodal embedding models across 500+ datasets, 1000+ languages, and tasks including retrieval, clustering, classification, and reranking.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.


### PR DESCRIPTION
Adds two well-established, actively maintained projects that are missing from the list.

## MLflow - LLM-as-Judge Evaluation section

- **Repo:** https://github.com/mlflow/mlflow
- **License:** Apache-2.0 (open source core, Databricks managed offering)
- **Stars:** 27k+
- MLflow has grown well beyond experiment tracking into a full AI engineering platform. It now ships 50+ built-in LLM judge metrics, pytest integration for regression testing of agents and RAG pipelines, and a multi-provider LLM playground. With 30M+ monthly downloads it is one of the most widely adopted tools in the space and a notable gap in the current list.

## MTEB - Benchmarks and Datasets section

- **Repo:** https://github.com/embeddings-benchmark/mteb
- **License:** Apache-2.0
- **Stars:** 3.4k
- MTEB (Massive Text Embedding Benchmark) is the standard community leaderboard for evaluating text and multimodal embedding models. It covers 500+ datasets across 1000+ languages and tasks (retrieval, clustering, classification, reranking, STS). It backs the Hugging Face MTEB Leaderboard and was updated as recently as July 2026 (v2.18.6). The benchmarks section already includes HELM and AgentBench-style agent evals; MTEB fills the embedding-model evaluation gap.

Both entries follow the existing format (linked name, badge, single-sentence description starting with uppercase and ending with a period, no em dashes).

---
_Generated by [Claude Code](https://claude.ai/code/session_016TBEeBVurxbS9cHbJYyQeQ)_