### PR TITLE
Add: ClawBench

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Learning resources for AI-powered testing.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
+- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) 🆓 - Open benchmark for evaluating AI web agents on 283 real-world tasks across live websites, with Docker-isolated runs and request interception before irreversible actions.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.


### PR DESCRIPTION
## What changed

Adds ClawBench to `Benchmarks and Datasets` using the list's required `Name / link / badge / one-sentence description` format.

## Why

ClawBench evaluates AI web agents on 283 real-world tasks across live websites, with Docker-isolated runs and interception of irreversible requests. This complements the section's WebArena, OSWorld, and AgentBench entries.

**Disclosure:** I am a ClawBench maintainer and am submitting this entry in that capacity.

## Checks

- Searched the default branch and all open/closed PRs and issues for the name, paper ID, project domain, and repository URL; no prior entry or submission was found.
- Verified the repository link resolves successfully.
- `git diff --check` passes.
- `awesome-lint` reports only the repository's existing metadata requirements for the `awesome` and `awesome-list` GitHub topics; it reports no README content errors.
