### PR TITLE
Add: truescore

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
 - [LangWatch](https://github.com/langwatch/langwatch) 🆓💰 - Open-source LLM evaluation and AI agent testing platform combining end-to-end scenario simulation, observability, and prompt management in a single unified loop.
 - [Evidently](https://github.com/evidentlyai/evidently) 🆓💰 - Open-source Python library for evaluating, testing, and monitoring ML and LLM systems with 100+ built-in metrics for data quality, drift detection, and LLM output quality.
+- [truescore](https://github.com/SaifPunjwani/truescore) 🆓 - Statistics for LLM-judge results: corrects the judge's score against a small set of human labels, reports confidence intervals, measures judge bias and agreement, and flags judge drift from CI.
 - [LangSmith](https://www.langchain.com/langsmith) 💰 - LangChain's platform for testing and monitoring LLM apps.
 - [Braintrust](https://www.braintrust.dev/) 💰 - LLM eval platform with experiments, datasets, and observability.
 - [Patronus AI](https://www.patronus.ai/) 💰 - Automated evaluation and security testing for LLMs.


### PR DESCRIPTION
Adds [truescore](https://github.com/SaifPunjwani/truescore) to **LLM-as-Judge Evaluation**, placed at the end of the open-source entries.

Everything in that section produces judge verdicts; nothing in it says whether those verdicts are trustworthy. truescore is the statistics layer on top: given judge verdicts on a full eval set plus human labels on a subset, it uses prediction-powered inference to correct the reported score and give a confidence interval, quantifies judge quality (sensitivity/specificity, Cohen's kappa, Gwet's AC1, Krippendorff's alpha), and tests whether the judge is biased by response length, self-preference or answer position. For QA use it also detects judge drift against a fingerprinted anchor set and exposes distinct CLI exit codes, so a pipeline can fail on a finding without also failing on a bad filename.

In the example shipped with the repo (simulated data, so ground truth is known) the judge reports a 0.8383 pass rate against a true 0.7140 and its interval excludes the truth, while the corrected estimate covers it. Apache-2.0, on PyPI as `truescore`, numpy and scipy the only dependencies, 602 tests including Monte Carlo coverage simulations, and a GitHub Action. It never calls a model, so it works with any of the runners already listed here.

Checklist:
- Uses AI/ML as a core feature, not a tagline: it is a library of estimators for LLM-judge output.
- Format `- [Name](link) BADGE - Description.` with the 🆓 badge, one sentence.
- Placed in the LLM-as-Judge Evaluation category, at the end of the open-source block.
- Individual pull request for a single suggestion; no duplicate in the README.
- Links checked.
