### PR TITLE
Add: AgentOps and BrowserGym

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 AI for failure analysis, flaky test detection, and reporting.
 
 - [agenttrace](https://github.com/luoyuctl/agenttrace) 🆓 - Local-first TUI and CLI for evaluating AI coding agent sessions with cost, token, latency, and failure regression gates.
+- [AgentOps](https://github.com/AgentOps-AI/agentops) 🆓💰 - Python SDK for AI agent observability, session replay, cost tracking, and failure detection across CrewAI, LangChain, and 20+ frameworks.
 - [ReportPortal](https://github.com/reportportal/reportportal) 🆓💰 - Open source results management with ML-based failure clustering.
 - [Allure TestOps](https://qameta.io/) 💰 - Test management with AI-driven analytics and flaky detection.
 - [Sealights](https://www.sealights.io/) 💰 - Quality intelligence platform using ML for test gap analysis.
@@ -295,6 +296,7 @@ Learning resources for AI-powered testing.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
+- [BrowserGym](https://github.com/ServiceNow/BrowserGym) 🆓 - Unified gym environment from ServiceNow Research for benchmarking web agents across nine suites including WebArena, WorkArena, VisualWebArena, and MiniWoB.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.


### PR DESCRIPTION
Adds two entries across two sections.

## AgentOps - Test Analytics and Triage

- **Link:** https://github.com/AgentOps-AI/agentops
- **License:** MIT (🆓💰 - open-source SDK with a hosted platform)
- **Stars:** 5.7k, actively maintained (811 commits, ongoing PRs)
- **Why it belongs:** AgentOps instruments AI agent runs with session replays, cost tracking, latency analytics, and failure detection across CrewAI, LangChain, OpenAI Agents SDK, and 20+ frameworks. This maps directly to the section's focus on failure analysis and analytics for AI-powered workflows.

## BrowserGym - Benchmarks and Datasets

- **Link:** https://github.com/ServiceNow/BrowserGym
- **License:** Apache 2.0 (🆓)
- **Stars:** 1.3k, actively maintained (385 commits)
- **Why it belongs:** BrowserGym, from ServiceNow Research, is a unified Gym environment that wraps nine web-agent benchmark suites - WebArena, WorkArena, VisualWebArena, MiniWoB, AssistantBench, WebLINX, OpenApps, TimeWarp, and WebArenaVerified - in a single consistent API. WebArena is already listed; BrowserGym makes it easier to run and compare agents across all nine at once, filling a gap in the benchmarks section.

Both entries follow the existing format, use a single sentence ending with a period, and contain no em dashes or double hyphens.

---
_Generated by [Claude Code](https://claude.ai/code/session_017WFHG1dHjNj1gaUcmgwpD7)_