### PR TITLE
Add truescore to LLM-as-Judge Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
 - [LangWatch](https://github.com/langwatch/langwatch) 🆓💰 - Open-source LLM evaluation and AI agent testing platform combining end-to-end scenario simulation, observability, and prompt management in a single unified loop.
 - [Evidently](https://github.com/evidentlyai/evidently) 🆓💰 - Open-source Python library for evaluating, testing, and monitoring ML and LLM systems with 100+ built-in metrics for data quality, drift detection, and LLM output quality.
+- [truescore](https://github.com/SaifPunjwani/truescore) 🆓 - Corrects LLM-judge scores for the judge's own error using a small set of human labels, with confidence intervals whose coverage is verified by simulation. Reads Promptfoo, DeepEval, Inspect AI and lm-evaluation-harness output directly.
 - [LangSmith](https://www.langchain.com/langsmith) 💰 - LangChain's platform for testing and monitoring LLM apps.
 - [Braintrust](https://www.braintrust.dev/) 💰 - LLM eval platform with experiments, datasets, and observability.
 - [Patronus AI](https://www.patronus.ai/) 💰 - Automated evaluation and security testing for LLMs.


### PR DESCRIPTION
Adds [truescore](https://github.com/SaifPunjwani/truescore) to the LLM-as-Judge Evaluation section.

It sits at a different point in the loop than the rest of that list. The other entries run judges; this one measures how wrong a judge was and corrects the score, using a small set of human labels on a random subset. The reason it belongs in a testing list is that it turns an eval number into something you can gate a release on: intervals with verified coverage, and exit codes for CI (0 no finding, 2 finding, 1 failed to run).

- Apache-2.0, numpy and scipy only, no API key, no data leaves the machine
- Reads Promptfoo, DeepEval, Inspect AI and lm-evaluation-harness output directly, so it works on files those tools already write
- Interval coverage is measured by simulation rather than asserted, across 650 tests

Worked example on public data: on MT-Bench, GPT-4 agrees with human judges 88% of the time and still reports its own win rate 12.7 points above theirs. https://saifpunjwani.github.io/truescore/findings/mt-bench.html

Happy to reword or drop the entry if it is out of scope for the list.