### PR TITLE
Add stealthy-auto-browse to Browser Automation for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Browser automation libraries designed for or commonly used by AI agents.
 - [Lightpanda](https://github.com/lightpanda-io/browser) 🆓 - Headless browser written in Zig, optimized for AI agents and scraping workloads.
 - [AgentQL](https://github.com/tinyfish-io/agentql) 🆓💰 - Natural language query language for AI agents to interact with and extract structured data from web pages, with self-healing selectors that integrate with Playwright.
 - [Browserbase](https://www.browserbase.com/) 💰 - Cloud browser infrastructure with natural language automation.
+- [stealthy-auto-browse](https://github.com/psyb0t/docker-stealthy-auto-browse) 🆓 - Stealth browser automation for AI agents: Camoufox (Firefox) in Docker with no CDP exposure and real OS-level input, driven over an HTTP API and MCP; passes Cloudflare, CreepJS and other bot detectors.
 
 ## Articles and Talks
 


### PR DESCRIPTION
Adds [stealthy-auto-browse](https://github.com/psyb0t/docker-stealthy-auto-browse) 🆓 (open source, 63★) to **Browser Automation for AI Agents**. It runs Camoufox (a de-CDP'd Firefox) in Docker with real OS-level mouse/keyboard input via PyAutoGUI, and exposes both an HTTP API and an MCP server so AI agents can drive it directly. Passes Cloudflare, CreepJS, BrowserScan and Pixelscan — useful for agent/E2E flows that hit bot-protected sites. Fits alongside the existing stealth option (Patchright) and the self-hostable ones (Steel Browser).