### PR TITLE
Add: OpenCompass and LiveBench to Benchmarks and Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,12 +292,14 @@ Learning resources for AI-powered testing.
 
 - [BenchClaw](https://github.com/Agnuxo1/BenchClaw) 🆓 - Multi-dimension AI benchmark with 17-judge evaluation tribunal for scientific paper generation. Evaluates IMRaD structure, citation quality, methodological rigor, and reproducibility across 10 dimensions with uncertainty quantification and P2P verification.
 - [HELM](https://github.com/stanford-crfm/helm) 🆓 - Stanford CRFM's open-source Python framework for holistic, reproducible, and transparent evaluation of LLMs and multimodal models across dozens of scenarios covering accuracy, robustness, efficiency, bias, and safety.
+- [OpenCompass](https://github.com/open-compass/opencompass) 🆓 - Comprehensive LLM and multimodal model evaluation platform from Shanghai AI Lab, supporting 100+ datasets and 70+ models with distributed evaluation, zero-shot and few-shot paradigms, and reproducible leaderboards.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.
+- [LiveBench](https://github.com/LiveBench/LiveBench) 🆓 - ICLR 2025 Spotlight benchmark designed to limit contamination by releasing new questions monthly across six categories, with objectively scorable ground-truth answers that require no LLM judge.
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
## Summary

Adds two well-established, actively maintained benchmarks to the **Benchmarks and Datasets** section.

### [OpenCompass](https://github.com/open-compass/opencompass) 🆓

- 7.2k stars, 1,204+ commits, last updated February 2026
- Comprehensive LLM and multimodal model evaluation platform from Shanghai AI Lab
- Supports 100+ datasets and 70+ models (GPT-4, Claude, Llama 3, Qwen, Mistral, and more)
- Distributed evaluation, zero-shot/few-shot/chain-of-thought paradigms, reproducible leaderboards
- Placed after HELM as a peer comprehensive evaluation framework

### [LiveBench](https://github.com/LiveBench/LiveBench) 🆓

- 1.3k stars, 490+ commits, ICLR 2025 Spotlight Paper
- Contamination-resistant benchmark with monthly question refreshes across six categories (math, coding, reasoning, data analysis, instruction following, language)
- Objectively scorable ground-truth answers - no LLM judge required
- Placed at the end of the section, after AgentBench

Both links resolve to active public repositories. Both are open source (🆓). Descriptions start with an uppercase letter and end with a period, matching the existing section style.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZSJS3PGJjuB8MxYKug4kY)_