### PR TITLE
Add: StructEval

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Learning resources for AI-powered testing.
 ## Benchmarks and Datasets
 
 - [BenchClaw](https://github.com/Agnuxo1/BenchClaw) 🆓 - Multi-dimension AI benchmark with 17-judge evaluation tribunal for scientific paper generation. Evaluates IMRaD structure, citation quality, methodological rigor, and reproducibility across 10 dimensions with uncertainty quantification and P2P verification.
+- [StructEval](https://github.com/TIGER-AI-Lab/StructEval) 🆓 - Benchmark for structured-output generation and cross-format conversion across text and renderable formats, with syntax, structural, and visual-fidelity checks.
 - [HELM](https://github.com/stanford-crfm/helm) 🆓 - Stanford CRFM's open-source Python framework for holistic, reproducible, and transparent evaluation of LLMs and multimodal models across dozens of scenarios covering accuracy, robustness, efficiency, bias, and safety.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.


### PR DESCRIPTION
Adds StructEval to Benchmarks and Datasets using the repository contribution format. It complements the existing benchmark resources with structured-output and cross-format evaluation.