### PR TITLE
Add: five46

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ End-to-end testing platforms with AI at the core.
 
 - [TestZeus Hercules](https://github.com/test-zeus-ai/testzeus-hercules) 🆓 - World's first open-source testing agent for UI, API, security, accessibility, and visual validations, no code required.
 - [agent-qa](https://github.com/vostride/agent-qa) 🆓 - Self-improving QA agent for natural-language web and mobile tests with run memory, UI-change adaptation, and regression detection.
+- [five46](https://github.com/sekharsdet/five46) 🆓 - BYOK CLI (OpenAI/Anthropic/Gemini/Groq/Bedrock) that drives a real browser or real HTTP requests toward a plain-English goal entirely locally, then writes the run as a real, standalone Playwright/`node:test` file with no five46/LLM needed to re-run it.
 - [Mabl](https://www.mabl.com/) 💰 - Low-code platform with auto-healing and ML-based test maintenance.
 - [Meticulous](https://www.meticulous.ai/) 💰 - Records real user sessions and generates regression tests automatically.
 - [Momentic](https://momentic.ai/) 💰 - AI-native end-to-end testing platform that writes, runs, and maintains web and mobile tests automatically using natural language.


### PR DESCRIPTION
Adding [five46](https://github.com/sekharsdet/five46) 🆓 to AI-Powered E2E Platforms.

five46 is a BYOK (OpenAI/Anthropic/Gemini/Groq/Bedrock) CLI that drives a real browser (or real HTTP requests, for API testing) toward a plain-English goal, one real action at a time, entirely locally with no cloud sandbox. A successful run writes a real, standalone Playwright `.spec.ts` (or `node:test` script for API tests) that's re-runnable forever with no five46 or LLM involved. Also ships an MCP server (`five46 mcp`) exposing the same engine as tools for an IDE-embedded AI assistant.

Starred the repo per the contribution guidelines.