### PR TITLE
Add: PurpleLlama and LiveBench

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Tools to test LLM applications themselves (security, robustness, hallucination).
 - [Guardrails AI](https://github.com/guardrails-ai/guardrails) 🆓💰 - Python framework for validating and structuring LLM outputs using composable validators covering toxicity, PII leakage, and hallucination detection.
 - [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) 🆓 - Open-source toolkit from NVIDIA for adding programmable guardrails to LLM-based conversational systems, preventing jailbreaks, topic drift, and unsafe outputs.
 - [PyRIT](https://github.com/Azure/PyRIT) 🆓 - Microsoft's Python Risk Identification Tool for generative AI.
+- [PurpleLlama](https://github.com/meta-llama/PurpleLlama) 🆓 - Meta's open-source cybersecurity safety evaluation suite for LLMs, covering insecure code generation, prompt injection, spear phishing, and autonomous cyber operations via the CyberSecEval benchmark series.
 - [LLM Guard](https://github.com/protectai/llm-guard) 🆓 - Open source security toolkit from Protect AI with scanners for prompt injection, toxicity, secrets, and data leakage in LLM inputs and outputs.
 - [LLMFuzzer](https://github.com/mnns/LLMFuzzer) 🆓 - Early open-source fuzzing framework for testing LLMs via their API integrations. No longer actively maintained (last commit early 2024) but still referenced in LLM security lists.
 - [Lakera Guard](https://www.lakera.ai/) 💰 - Real-time prompt injection and jailbreak detection.
@@ -298,6 +299,7 @@ Learning resources for AI-powered testing.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.
+- [LiveBench](https://github.com/LiveBench/LiveBench) 🆓 - Contamination-free LLM benchmark with monthly question updates across 18 tasks and 6 categories, using objective scoring without LLM judges.
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
## What's added

**LLM and AI System Testing**

- [PurpleLlama](https://github.com/meta-llama/PurpleLlama) - Meta's open-source cybersecurity safety evaluation suite for LLMs. It houses the CyberSecEval benchmark series (v1, v2, v3), which measures insecure code generation rates, prompt injection susceptibility, spear phishing capability, and autonomous offensive cyber operations. 4.3k stars, actively maintained.

**Benchmarks and Datasets**

- [LiveBench](https://github.com/LiveBench/LiveBench) - Contamination-free LLM benchmark that releases new questions monthly sourced from recent papers, competitions, and news, avoiding the data-leakage problem that affects static benchmarks. Covers 18 tasks across 6 categories with objective, judge-free scoring. 1.3k stars, last release April 2025.

## Why these

- Neither is already in the list.
- Both use AI/ML as a core feature, not a marketing label.
- Both are open source, actively maintained, and from credible sources (Meta AI and an academic research group).
- PurpleLlama fills a gap in the security section - no entry from Meta previously.
- LiveBench's contamination-free design is genuinely distinct from the other benchmarks already listed (HELM, SWE-bench, HumanEval, WebArena, OSWorld, tau-bench, AgentBench).

## Checklist

- [x] Entries follow the `- [Name](link) BADGE - Description.` format
- [x] Descriptions are one sentence, start with uppercase, end with a period
- [x] No em dashes used
- [x] No duplicates (searched README before adding)
- [x] Links verified as active before submission

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHLzDp91dCNSkGmGe9hvdK)_