### PR TITLE
Add: EvalPlus and CyberSecEval

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Tools to test LLM applications themselves (security, robustness, hallucination).
 - [Guardrails AI](https://github.com/guardrails-ai/guardrails) 🆓💰 - Python framework for validating and structuring LLM outputs using composable validators covering toxicity, PII leakage, and hallucination detection.
 - [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) 🆓 - Open-source toolkit from NVIDIA for adding programmable guardrails to LLM-based conversational systems, preventing jailbreaks, topic drift, and unsafe outputs.
 - [PyRIT](https://github.com/Azure/PyRIT) 🆓 - Microsoft's Python Risk Identification Tool for generative AI.
+- [CyberSecEval](https://github.com/meta-llama/PurpleLlama/tree/main/CybersecurityBenchmarks) 🆓 - Meta's multi-version cybersecurity benchmark suite for LLMs, covering insecure code generation, prompt injection, exploitation assistance, and autonomous vulnerability patching.
 - [LLM Guard](https://github.com/protectai/llm-guard) 🆓 - Open source security toolkit from Protect AI with scanners for prompt injection, toxicity, secrets, and data leakage in LLM inputs and outputs.
 - [LLMFuzzer](https://github.com/mnns/LLMFuzzer) 🆓 - Early open-source fuzzing framework for testing LLMs via their API integrations. No longer actively maintained (last commit early 2024) but still referenced in LLM security lists.
 - [Lakera Guard](https://www.lakera.ai/) 💰 - Real-time prompt injection and jailbreak detection.
@@ -294,6 +295,7 @@ Learning resources for AI-powered testing.
 - [HELM](https://github.com/stanford-crfm/helm) 🆓 - Stanford CRFM's open-source Python framework for holistic, reproducible, and transparent evaluation of LLMs and multimodal models across dozens of scenarios covering accuracy, robustness, efficiency, bias, and safety.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
+- [EvalPlus](https://github.com/evalplus/evalplus) 🆓 - Rigorous code generation benchmark that extends HumanEval and MBPP with 80x and 35x more automated test cases for stricter LLM evaluation.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.


### PR DESCRIPTION
Adds two new entries that are not yet in the list.

## EvalPlus

- **Section:** Benchmarks and Datasets (placed after HumanEval, which it extends)
- **Link:** https://github.com/evalplus/evalplus
- **Badge:** 🆓
- **Why:** EvalPlus is a widely-used, actively maintained (last commit October 2025) benchmark that augments HumanEval with 80x more test cases and MBPP with 35x more, enabling far stricter evaluation of LLM code generation. It has 1.8k stars and is the standard reference for rigorous code-generation evaluation in academic and industry settings.

## CyberSecEval

- **Section:** LLM and AI System Testing (placed after PyRIT)
- **Link:** https://github.com/meta-llama/PurpleLlama/tree/main/CybersecurityBenchmarks
- **Badge:** 🆓
- **Why:** Meta's CyberSecEval is an actively maintained (CyberSecEval 4 released April 2025) multi-version benchmark suite covering insecure code generation, prompt injection, exploit assistance, and autonomous vulnerability patching. It sits on the PurpleLlama repo (~4.3k stars) and has been applied to models from Meta, OpenAI, Google, and Anthropic.

Both entries follow the existing format: single sentence description starting with uppercase and ending with a period, 🆓 badge, no em dashes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFne1GKMVknU77X4AnqRHE)_