### PR TITLE
Add: LiveBench

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Learning resources for AI-powered testing.
 
 - [BenchClaw](https://github.com/Agnuxo1/BenchClaw) 🆓 - Multi-dimension AI benchmark with 17-judge evaluation tribunal for scientific paper generation. Evaluates IMRaD structure, citation quality, methodological rigor, and reproducibility across 10 dimensions with uncertainty quantification and P2P verification.
 - [HELM](https://github.com/stanford-crfm/helm) 🆓 - Stanford CRFM's open-source Python framework for holistic, reproducible, and transparent evaluation of LLMs and multimodal models across dozens of scenarios covering accuracy, robustness, efficiency, bias, and safety.
+- [LiveBench](https://github.com/livebench/livebench) 🆓 - Contamination-free LLM benchmark (ICLR 2025 Spotlight) that releases new questions monthly from recent sources across 18 tasks in math, coding, and reasoning, scored with objective verifiable answers instead of LLM judges.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.


### PR DESCRIPTION
Adds [LiveBench](https://github.com/livebench/livebench) to the **Benchmarks and Datasets** section.

**Why it belongs here:**
- Contamination-free LLM benchmark that releases new questions monthly from recent sources (arXiv papers, news, math competitions), making it resistant to training data leakage
- Accepted as a Spotlight paper at ICLR 2025
- 18 tasks spanning math, coding, reasoning, data analysis, language, and instruction following
- Scores with objective, verifiable ground-truth answers rather than LLM judges, removing a major source of evaluation noise
- Actively maintained with 500+ commits and regular monthly releases

Placed after HELM as the next general-purpose LLM evaluation benchmark.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR9CHfgH8MxC8sUGLDUUe6)_