### PR TITLE
Add: Lighteval

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Weights & Biases Weave](https://github.com/wandb/weave) 🆓💰 - Weights & Biases toolkit for tracing, debugging, and evaluating generative AI applications with built-in LLM-as-judge metrics and dataset management.
 - [OpenAI Evals](https://github.com/openai/evals) 🆓 - Framework for evaluating LLMs and an open-source registry of benchmarks from OpenAI. No longer actively maintained for new evals, but still widely used as a reference.
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) 🆓 - EleutherAI's framework for few-shot evaluation of language models, backing the Hugging Face Open LLM Leaderboard.
+- [Lighteval](https://github.com/huggingface/lighteval) 🆓 - Hugging Face's all-in-one LLM evaluation toolkit with 1,000+ tasks and support for multiple inference backends including Accelerate, vLLM, and TGI.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
 - [Helicone](https://github.com/Helicone/helicone) 🆓💰 - Open source LLM observability and prompt evaluation platform.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.


### PR DESCRIPTION
Adds [Lighteval](https://github.com/huggingface/lighteval) to the **LLM-as-Judge Evaluation** section.

**Why it belongs here:**
- Hugging Face's official LLM evaluation toolkit, developed by the same team that maintains the Open LLM Leaderboard
- 1,000+ evaluation tasks spanning knowledge, math, coding, multilingual (200+ languages), and language understanding
- Supports multiple inference backends: Accelerate, vLLM, SGLang, TGI, and inspect-ai
- Actively maintained with 2.5k stars, 586 commits, and ongoing community contributions
- Saves sample-level results for debugging, making it useful for test-style analysis of model behavior

Placed directly after `lm-evaluation-harness` as a natural companion - both are general-purpose evaluation harnesses, with Lighteval being the Hugging Face-native counterpart.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR9CHfgH8MxC8sUGLDUUe6)_