### PR TITLE
Add: Adversarial Robustness Toolbox and CyberSecEval

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Tools to test LLM applications themselves (security, robustness, hallucination).
 - [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) 🆓 - Open-source toolkit from NVIDIA for adding programmable guardrails to LLM-based conversational systems, preventing jailbreaks, topic drift, and unsafe outputs.
 - [PyRIT](https://github.com/Azure/PyRIT) 🆓 - Microsoft's Python Risk Identification Tool for generative AI.
 - [LLM Guard](https://github.com/protectai/llm-guard) 🆓 - Open source security toolkit from Protect AI with scanners for prompt injection, toxicity, secrets, and data leakage in LLM inputs and outputs.
+- [Adversarial Robustness Toolbox](https://github.com/Trusted-AI/adversarial-robustness-toolbox) 🆓 - IBM Research and Linux Foundation Python library for evaluating ML model security against evasion, poisoning, extraction, and inference attacks across TensorFlow, PyTorch, and scikit-learn.
 - [LLMFuzzer](https://github.com/mnns/LLMFuzzer) 🆓 - Early open-source fuzzing framework for testing LLMs via their API integrations. No longer actively maintained (last commit early 2024) but still referenced in LLM security lists.
 - [Lakera Guard](https://www.lakera.ai/) 💰 - Real-time prompt injection and jailbreak detection.
 - [Prompt Security](https://www.prompt.security/) 💰 - Runtime prompt injection and data leak protection platform.
@@ -298,6 +299,7 @@ Learning resources for AI-powered testing.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.
+- [CyberSecEval](https://github.com/meta-llama/PurpleLlama) 🆓 - Meta's benchmark suite for evaluating LLM cybersecurity risk across insecure code generation, prompt injection susceptibility, and autonomous offensive cyber operations, with a public Hugging Face leaderboard.
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
## What's added

Two new entries in sections that fit their scope:

### LLM and AI System Testing

**[Adversarial Robustness Toolbox](https://github.com/Trusted-AI/adversarial-robustness-toolbox)** (🆓)

IBM Research's Python library, now hosted under the Linux Foundation AI and Data Foundation. Tests ML model security against evasion attacks (inputs crafted to fool the model), poisoning attacks (corrupting training data), model extraction, and inference attacks. Supports TensorFlow, Keras, PyTorch, scikit-learn, XGBoost, and others. 6.2k stars, 13k+ commits, actively maintained.

Inserted after LLM Guard, before the archived LLMFuzzer entry - consistent with the section's rough ordering by prominence.

### Benchmarks and Datasets

**[CyberSecEval](https://github.com/meta-llama/PurpleLlama)** (🆓)

Meta's benchmark suite for measuring LLM cybersecurity risk, described as the first industry-wide evaluation of its kind. Now at version 3, covering insecure code suggestion detection, prompt injection susceptibility, code interpreter abuse, and autonomous offensive cyber operation capability. Results are published on a public Hugging Face leaderboard. 4.3k stars, actively developed.

Added at the end of the Benchmarks section, where security-focused and agent-focused benchmarks already sit.

---

Both links resolve to active projects. Neither entry was previously in the list. Descriptions follow the existing format: one sentence, ends with a period, no em dashes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqUFutEyRKPvor1pDvfBcq)_