### PR TITLE
Add: EvalPlus and mcp-scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Tools to test LLM applications themselves (security, robustness, hallucination).
 - [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) 🆓 - Open-source toolkit from NVIDIA for adding programmable guardrails to LLM-based conversational systems, preventing jailbreaks, topic drift, and unsafe outputs.
 - [PyRIT](https://github.com/Azure/PyRIT) 🆓 - Microsoft's Python Risk Identification Tool for generative AI.
 - [LLM Guard](https://github.com/protectai/llm-guard) 🆓 - Open source security toolkit from Protect AI with scanners for prompt injection, toxicity, secrets, and data leakage in LLM inputs and outputs.
+- [mcp-scan](https://github.com/invariantlabs-ai/mcp-scan) 🆓 - Security scanner for MCP servers and agent skills that detects prompt injection, tool poisoning, and cross-origin escalations through static and dynamic analysis.
 - [LLMFuzzer](https://github.com/mnns/LLMFuzzer) 🆓 - Early open-source fuzzing framework for testing LLMs via their API integrations. No longer actively maintained (last commit early 2024) but still referenced in LLM security lists.
 - [Lakera Guard](https://www.lakera.ai/) 💰 - Real-time prompt injection and jailbreak detection.
 - [Prompt Security](https://www.prompt.security/) 💰 - Runtime prompt injection and data leak protection platform.
@@ -295,6 +296,7 @@ Learning resources for AI-powered testing.
 - [HELM](https://github.com/stanford-crfm/helm) 🆓 - Stanford CRFM's open-source Python framework for holistic, reproducible, and transparent evaluation of LLMs and multimodal models across dozens of scenarios covering accuracy, robustness, efficiency, bias, and safety.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
+- [EvalPlus](https://github.com/evalplus/evalplus) 🆓 - Rigorous LLM code evaluation framework that extends HumanEval and MBPP with up to 80x more auto-generated test cases, catching wrong code that basic benchmarks miss.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.


### PR DESCRIPTION
Adds two notable open-source tools that are not currently listed.

## EvalPlus

- **Repo:** https://github.com/evalplus/evalplus
- **Section:** Benchmarks and Datasets
- **Why:** Well-established LLM code evaluation framework (NeurIPS 2023, COLM 2024) with 1.8k stars. Extends HumanEval with 80x more auto-generated test cases and MBPP with 35x more, catching wrong code that the original benchmarks miss. Adopted by Meta, Qwen, DeepSeek, and Snowflake for benchmarking code generation models. Placed after HumanEval since it directly extends that benchmark.

## mcp-scan

- **Repo:** https://github.com/invariantlabs-ai/mcp-scan
- **Section:** LLM and AI System Testing
- **Why:** Active security scanner (2.9k stars) that detects prompt injection, tool poisoning, and cross-origin escalations in MCP servers and agent skills through static and dynamic analysis. Directly relevant as MCP usage in AI testing pipelines grows. Placed before LLMFuzzer (which is noted as unmaintained) among the open-source security tools.

## Checklist

- awesome-lint passes with no errors
- No duplicate entries
- Format matches existing entries (badge, one-sentence description ending with a period, no em dashes)
- Both repositories are active and resolve correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_013u4u6p35YciEGPqUWuuHPf)_