### PR TITLE
Add: PurpleLlama and LiveBench

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ AI features for API testing, schema generation, and contract validation.
 Tools to test LLM applications themselves (security, robustness, hallucination).
 
 - [Garak](https://github.com/NVIDIA/garak) 🆓 - LLM vulnerability scanner from NVIDIA.
+- [PurpleLlama](https://github.com/meta-llama/PurpleLlama) 🆓 - Meta's open-source toolkit for responsible LLM development, combining CyberSecEval cybersecurity benchmarks with Llama Guard safeguards for inputs and outputs.
 - [DeepTeam](https://github.com/confident-ai/deepteam) 🆓 - LLM red teaming for prompt injection, jailbreaks, and data leaks.
 - [llm-security-scanner](https://github.com/tugkanboz/llm-security-scanner) 🆓 - Red-team toolkit with OWASP LLM Top 10 alignment and Turkish payload library.
 - [Giskard](https://github.com/Giskard-AI/giskard) 🆓💰 - Testing framework for LLMs and ML models.
@@ -299,6 +300,7 @@ Learning resources for AI-powered testing.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.
+- [LiveBench](https://github.com/livebench/livebench) 🆓 - ICLR 2025 Spotlight benchmark for LLMs designed to prevent data contamination by releasing new questions monthly from recent papers, news articles, and datasets, with verifiable ground-truth answers across 18 diverse tasks.
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
Two new additions to fill clear gaps in existing sections.

## LLM and AI System Testing - PurpleLlama

- **Repo:** https://github.com/meta-llama/PurpleLlama
- **Stars:** 4.3k
- **License:** Open source (Meta)
- **Why:** Meta's umbrella toolkit for responsible LLM deployment. Notably includes CyberSecEval (now v4), the most widely cited industry benchmark for measuring insecure code generation, prompt injection susceptibility, and offensive cyber capabilities in LLMs. Also bundles Llama Guard for runtime input/output safeguarding. No comparable Meta safety toolkit is currently listed; Garak (NVIDIA) and PyRIT (Microsoft) are there but the Meta equivalent is missing.

## Benchmarks and Datasets - LiveBench

- **Repo:** https://github.com/livebench/livebench
- **Stars:** 1.3k
- **License:** MIT
- **Why:** ICLR 2025 Spotlight paper. Addresses data contamination - a known blind spot of static benchmarks - by replacing one-sixth of its questions monthly with items drawn from recent arXiv papers, news, and datasets. Every question has an objective, verifiable ground-truth answer so no LLM judge is needed. Sits naturally after AgentBench (ICLR 2024) in the section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJuqLrTpqTCSRpmGEZW89u)_