### PR TITLE
Add: OpenLIT and BrowserGym

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
 - [Helicone](https://github.com/Helicone/helicone) 🆓💰 - Open source LLM observability and prompt evaluation platform.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
+- [OpenLIT](https://github.com/openlit/openlit) 🆓 - OpenTelemetry-native open-source platform for LLM observability, evaluation, and guardrails with 11 built-in LLM-as-judge metrics covering hallucination, bias, toxicity, and faithfulness.
 - [LangWatch](https://github.com/langwatch/langwatch) 🆓💰 - Open-source LLM evaluation and AI agent testing platform combining end-to-end scenario simulation, observability, and prompt management in a single unified loop.
 - [Evidently](https://github.com/evidentlyai/evidently) 🆓💰 - Open-source Python library for evaluating, testing, and monitoring ML and LLM systems with 100+ built-in metrics for data quality, drift detection, and LLM output quality.
 - [LangSmith](https://www.langchain.com/langsmith) 💰 - LangChain's platform for testing and monitoring LLM apps.
@@ -299,6 +300,7 @@ Learning resources for AI-powered testing.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.
+- [BrowserGym](https://github.com/ServiceNow/BrowserGym) 🆓 - Gymnasium-based environment from ServiceNow Research that unifies nine web-agent benchmarks for standardized, reproducible evaluation of browser-using AI agents.
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
## Summary

Two new entries, each verified for activity and relevance before adding.

### LLM-as-Judge Evaluation - OpenLIT

- **Repo**: https://github.com/openlit/openlit
- **License**: Apache-2.0
- **Stars**: 2.7k
- **Why it belongs**: OpenTelemetry-native open-source platform for LLM observability, evaluation, and guardrails. Includes 11 built-in LLM-as-judge evaluation types (hallucination, bias, toxicity, faithfulness, instruction adherence, completeness, conciseness, sensitivity, relevance, coherence, safety), making it a genuine evaluation tool rather than just a tracing layer. Auto-instruments 50+ providers with a single line of code. Actively maintained - last commit July 2026.

### Benchmarks and Datasets - BrowserGym

- **Repo**: https://github.com/ServiceNow/BrowserGym
- **License**: Apache-2.0
- **Stars**: 1.3k
- **Why it belongs**: Gymnasium-based environment from ServiceNow Research (published in TMLR 2025) that provides a unified, standardized interface to nine web-agent benchmarks - MiniWoB, WebArena, WebArenaVerified, VisualWebArena, WorkArena, AssistantBench, WebLINX, OpenApps, and TimeWarp. Fills a gap in the benchmarks section as the go-to harness for reproducible web-agent evaluation.

## Checklist

- Links verified and resolve to active projects
- Format matches existing entries (`- [Name](link) BADGE - Description.`)
- No em dashes used
- Single-sentence descriptions, starting uppercase, ending with period
- Placed in the most appropriate existing sections
- awesome-lint passes locally

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGoWYsFKh39q2bstKjaGAT)_