### PR TITLE
Add: AgentOps and VisualWebArena

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 AI for failure analysis, flaky test detection, and reporting.
 
 - [agenttrace](https://github.com/luoyuctl/agenttrace) 🆓 - Local-first TUI and CLI for evaluating AI coding agent sessions with cost, token, latency, and failure regression gates.
+- [AgentOps](https://github.com/AgentOps-AI/agentops) 🆓💰 - Python SDK for testing and debugging AI agents with session replay, LLM cost tracking, and native integrations for CrewAI, LangChain, OpenAI Agents SDK, and AutoGen.
 - [ReportPortal](https://github.com/reportportal/reportportal) 🆓💰 - Open source results management with ML-based failure clustering.
 - [Allure TestOps](https://qameta.io/) 💰 - Test management with AI-driven analytics and flaky detection.
 - [Sealights](https://www.sealights.io/) 💰 - Quality intelligence platform using ML for test gap analysis.
@@ -296,6 +297,7 @@ Learning resources for AI-powered testing.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
+- [VisualWebArena](https://github.com/web-arena-x/visualwebarena) 🆓 - Benchmark for evaluating multimodal autonomous web agents across 910 tasks spanning realistic web environments, requiring image-text comprehension and spatial reasoning.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.


### PR DESCRIPTION
Two additions to separate sections.

## AgentOps - Test Analytics and Triage

- **Project:** https://github.com/AgentOps-AI/agentops
- **License:** MIT (open source with hosted dashboard)
- **Stars:** 5.6k+, last updated June 2026
- **Why:** Python SDK explicitly for testing and debugging AI agents - covers session replay, LLM cost tracking, failure detection, and latency benchmarking. Integrates natively with CrewAI, LangChain, OpenAI Agents SDK, AutoGen, AG2, and CamelAI. Fills a genuine gap in the "Test Analytics and Triage" section, which focuses on monitoring and analysis but had no entry specifically targeting AI agent sessions.

## VisualWebArena - Benchmarks and Datasets

- **Project:** https://github.com/web-arena-x/visualwebarena
- **License:** Apache-2.0
- **Why:** Multimodal companion to WebArena (already listed). Provides 910 evaluation tasks across Classifieds, Shopping, and Reddit environments where agents must process images alongside text to act on web pages. Widely cited benchmark for evaluating vision-language web agents; complements WebArena and AgentBench already in the section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nu6Gcwmwy8s8Rrmh1k78ju)_