### PR TITLE
Add: OpenLLMetry and MTEB

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
 - [LangWatch](https://github.com/langwatch/langwatch) 🆓💰 - Open-source LLM evaluation and AI agent testing platform combining end-to-end scenario simulation, observability, and prompt management in a single unified loop.
 - [Evidently](https://github.com/evidentlyai/evidently) 🆓💰 - Open-source Python library for evaluating, testing, and monitoring ML and LLM systems with 100+ built-in metrics for data quality, drift detection, and LLM output quality.
+- [OpenLLMetry](https://github.com/traceloop/openllmetry) 🆓 - OpenTelemetry-based instrumentation library that automatically traces LLM calls to all major providers and vector databases and exports to any OTel-compatible observability backend.
 - [LangSmith](https://www.langchain.com/langsmith) 💰 - LangChain's platform for testing and monitoring LLM apps.
 - [Braintrust](https://www.braintrust.dev/) 💰 - LLM eval platform with experiments, datasets, and observability.
 - [Patronus AI](https://www.patronus.ai/) 💰 - Automated evaluation and security testing for LLMs.
@@ -299,6 +300,7 @@ Learning resources for AI-powered testing.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.
+- [MTEB](https://github.com/embeddings-benchmark/mteb) 🆓 - Massive Text Embedding Benchmark that evaluates text and multimodal embedding models across retrieval, clustering, classification, and semantic similarity tasks with a public interactive leaderboard.
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
## What this adds

**OpenLLMetry** - added to [LLM-as-Judge Evaluation]
- GitHub: https://github.com/traceloop/openllmetry
- 7.4k stars, Apache 2.0, actively maintained
- OpenTelemetry-native instrumentation for LLM applications that automatically traces calls to all major providers (OpenAI, Anthropic, etc.) and vector databases, then exports to any OTel-compatible backend
- Fills a distinct niche from the existing observability tools in the section: it is a vendor-neutral instrumentation layer (OTel standard) rather than a standalone evaluation platform

**MTEB** - added to [Benchmarks and Datasets]
- GitHub: https://github.com/embeddings-benchmark/mteb
- 3.4k stars, actively maintained with 4,456 commits
- The standard benchmark for evaluating text and multimodal embedding models, covering retrieval, clustering, classification, and semantic similarity with a public interactive leaderboard
- Complements the existing code and agent-focused benchmarks in the section by covering the embedding model evaluation angle

## Checklist

- Both links verified to resolve to active, publicly accessible projects
- Both entries follow the existing format: `- [Name](url) BADGE - Description.`
- Descriptions are single sentences starting with uppercase and ending with a period
- No em dashes used anywhere
- Neither project is already present in the list
- Placed in the most appropriate existing sections
- Both projects have AI/ML as a core feature, not a tagline

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nb2651QnDtbufAHDYtPtc8)_