### PR TITLE
Add: TestSpark and VisualWebArena

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Tools that generate test cases from code, requirements, or user behavior using A
 - [EvoMaster](https://github.com/EMResearch/EvoMaster) 🆓 - First open source AI tool that automatically generates test cases via evolutionary algorithms for REST, GraphQL, and RPC APIs.
 - [EvoSuite](https://github.com/EvoSuite/evosuite) 🆓 - Generates JUnit tests using evolutionary and genetic search-based algorithms for Java.
 - [Pynguin](https://github.com/se2p/pynguin) 🆓 - Automated unit test generation for Python via evolutionary algorithms, from Saarland University.
+- [TestSpark](https://github.com/JetBrains-Research/TestSpark) 🆓 - IntelliJ IDEA plugin from JetBrains Research that integrates LLM-based and search-based techniques to generate unit tests for Java and Kotlin.
 - [Symflower](https://symflower.com/) 💰 - Commercial tool that combines symbolic execution, static analysis, and LLMs to generate unit tests for Java, Go, and Kotlin. Free CLI available with limitations.
 - [CodiumAI / Qodo](https://www.qodo.ai/) 💰 - AI assistant generating meaningful tests from code context.
 - [Diffblue Cover](https://www.diffblue.com/) 💰 - Autonomous Java unit test writer using reinforcement learning.
@@ -296,6 +297,7 @@ Learning resources for AI-powered testing.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
+- [VisualWebArena](https://github.com/web-arena-x/visualwebarena) 🆓 - CVPR 2024 benchmark for evaluating multimodal web agents on realistic tasks that require visual grounding across product, forum, and shopping sites.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.
 - [AgentBench](https://github.com/THUDM/AgentBench) 🆓 - ICLR 2024 benchmark for evaluating LLMs as autonomous agents across eight environments including OS, database, web browsing, and game tasks.


### PR DESCRIPTION
## What this adds

**[TestSpark](https://github.com/JetBrains-Research/TestSpark)** - added to *Test Generation*

An IntelliJ IDEA plugin from JetBrains Research that natively integrates LLM-based and search-based techniques (EvoSuite, Randoop) to generate unit tests for Java and Kotlin. Started at TU Delft's SERG group, now actively maintained by JetBrains Research with the most recent commit in July 2026. MIT license.

**[VisualWebArena](https://github.com/web-arena-x/visualwebarena)** - added to *Benchmarks and Datasets*

A CVPR 2024 benchmark from the same group behind WebArena (already listed). It extends WebArena with visual grounding tasks across product, forum, and shopping sites, making it the standard benchmark for evaluating multimodal web agents. MIT license, 485 stars.

## Checklist

- Both links resolve to active, public GitHub repositories.
- Neither entry duplicates an existing listing.
- Format matches the existing style: linked name, badge, single sentence ending with a period, no em dashes.
- Entries are placed in the most appropriate section (TestSpark after Pynguin in Test Generation; VisualWebArena after WebArena in Benchmarks and Datasets).
- Both tools use AI/LLMs as a core feature, not as a marketing tagline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BS6ydwNnif7NssEJcxxYKX)_