### PR TITLE
Add: EvalPlus

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Learning resources for AI-powered testing.
 - [HELM](https://github.com/stanford-crfm/helm) 🆓 - Stanford CRFM's open-source Python framework for holistic, reproducible, and transparent evaluation of LLMs and multimodal models across dozens of scenarios covering accuracy, robustness, efficiency, bias, and safety.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
+- [EvalPlus](https://github.com/evalplus/evalplus) 🆓 - Rigorous code generation benchmark that augments HumanEval and MBPP with 80x more LLM-generated tests, plus code efficiency evaluation via EvalPerf.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.


### PR DESCRIPTION
Adds [EvalPlus](https://github.com/evalplus/evalplus) to the **Benchmarks and Datasets** section.

EvalPlus is a rigorous LLM code generation benchmark from NeurIPS 2023 (follow-up at COLM 2024) that augments HumanEval with 80x more test cases and MBPP with 35x more, catching bugs that the original suites miss. It also includes EvalPerf for code efficiency evaluation. The project is open-source (MIT), has 1.8k stars, and was actively released in October 2024.

- Placed immediately after HumanEval, which it directly extends.
- No em dashes used; format matches existing entries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfQ4zf47TEAqmp374iSvBm)_