### PR TITLE
Add: OpenCompass

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Weights & Biases Weave](https://github.com/wandb/weave) 🆓💰 - Weights & Biases toolkit for tracing, debugging, and evaluating generative AI applications with built-in LLM-as-judge metrics and dataset management.
 - [OpenAI Evals](https://github.com/openai/evals) 🆓 - Framework for evaluating LLMs and an open-source registry of benchmarks from OpenAI. No longer actively maintained for new evals, but still widely used as a reference.
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) 🆓 - EleutherAI's framework for few-shot evaluation of language models, backing the Hugging Face Open LLM Leaderboard.
+- [OpenCompass](https://github.com/open-compass/opencompass) 🆓 - Comprehensive LLM evaluation platform from Shanghai AI Lab supporting 100+ models and 100+ datasets across zero-shot, few-shot, and chain-of-thought paradigms.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
 - [Helicone](https://github.com/Helicone/helicone) 🆓💰 - Open source LLM observability and prompt evaluation platform.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.


### PR DESCRIPTION
Adds [OpenCompass](https://github.com/open-compass/opencompass) to the **LLM-as-Judge Evaluation** section.

OpenCompass is a comprehensive open-source LLM evaluation platform from Shanghai AI Lab. It supports 100+ models (GPT-4, Claude, Llama, Mistral, Qwen, GLM, InternLM, and more) across 100+ datasets with distributed evaluation and zero-shot, few-shot, and chain-of-thought paradigms. It has 7.3k stars and was last updated in February 2026, indicating very active maintenance.

- Placed after `lm-evaluation-harness`, which it naturally complements as a broader evaluation framework.
- No em dashes used; format matches existing entries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfQ4zf47TEAqmp374iSvBm)_