### PR TITLE
Add: LiveCodeBench and Notte

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Browser automation libraries designed for or commonly used by AI agents.
 - [Patchright](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright) 🆓 - Patched Playwright for stealth automation.
 - [Lightpanda](https://github.com/lightpanda-io/browser) 🆓 - Headless browser written in Zig, optimized for AI agents and scraping workloads.
 - [AgentQL](https://github.com/tinyfish-io/agentql) 🆓💰 - Natural language query language for AI agents to interact with and extract structured data from web pages, with self-healing selectors that integrate with Playwright.
+- [Notte](https://github.com/nottelabs/notte) 🆓💰 - Open-source web agent framework that converts web pages into structured, LLM-readable action spaces for faster and more cost-efficient browser automation.
 - [Browserbase](https://www.browserbase.com/) 💰 - Cloud browser infrastructure with natural language automation.
 
 ## Articles and Talks
@@ -295,6 +296,7 @@ Learning resources for AI-powered testing.
 - [HELM](https://github.com/stanford-crfm/helm) 🆓 - Stanford CRFM's open-source Python framework for holistic, reproducible, and transparent evaluation of LLMs and multimodal models across dozens of scenarios covering accuracy, robustness, efficiency, bias, and safety.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
+- [LiveCodeBench](https://github.com/LiveCodeBench/LiveCodeBench) 🆓 - Contamination-free benchmark that continuously collects fresh coding problems from LeetCode, AtCoder, and Codeforces to evaluate LLMs on code generation, execution, and self-repair.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.


### PR DESCRIPTION
Adds two new entries to the list.

**[LiveCodeBench](https://github.com/LiveCodeBench/LiveCodeBench)** - added to **Benchmarks and Datasets**

A contamination-free coding benchmark (NeurIPS 2024) that continuously pulls fresh problems from LeetCode, AtCoder, and Codeforces. Evaluates LLMs across code generation, execution, test-output prediction, and self-repair tasks. 934 stars, MIT licensed, actively maintained.

**[Notte](https://github.com/nottelabs/notte)** - added to **Browser Automation for AI Agents**

An open-source web agent framework that converts web pages into structured, LLM-readable action spaces rather than feeding raw HTML or screenshots to the model. Reduces token cost by 50%+ compared to screenshot-based approaches. 2 000+ stars, SSPL-1.0 with a commercial hosted tier (badged 🆓💰), actively maintained.

Both links resolve to active GitHub repositories. Descriptions follow the existing format: linked name, badge, single sentence starting with an uppercase letter and ending with a period, no em dashes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbgqNqqburrFekKdjKNnWw)_