### PR TITLE
Add: Optics Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Tools that automatically repair broken test locators and adapt to UI changes.
 
 - [Healenium](https://github.com/healenium/healenium) 🆓 - Self-healing library for Selenium, Appium, and Playwright. Replaces broken selectors at runtime.
 - [CodeceptJS](https://github.com/codeceptjs/CodeceptJS) 🆓 - End-to-end testing framework with built-in AI heal plugin that uses OpenAI, Anthropic, or local models to repair failing steps and propose locator fixes.
+- [optics-framework](https://github.com/mozarkai/optics-framework) 🆓 - Open-source test automation for mobile, web and Smart TV with a locator fallback ladder across XPath, text, OCR and image strategies, plus optional LLM-driven self-healing that recovers failed steps through the same keyword API.
 - [Testim](https://www.testim.io/) 💰 - Pioneer of self-healing tests with AI-driven smart locators.
 - [Functionize](https://www.functionize.com/) 💰 - AI-powered tests that adapt without selectors.
 - [TestSigma](https://testsigma.com/) 💰 - AI-driven low-code platform with self-healing across web, mobile, and API.


### PR DESCRIPTION
Adds [optics-framework](https://github.com/mozarkai/optics-framework) to **Self-Healing Test Frameworks**.

- AI is core, not marketing: a locator fallback ladder (XPath → visible text → OCR → image) runs on every element interaction, and an optional LLM-driven self-heal (ReAct-style, screenshot + page-source + intent) recovers failed steps through the same keyword API. Also ships an MCP server (`optics mcp`) exposing keywords to AI agents.
- Format followed: `- [Name](link) 🆓 - Description.` — Apache-2.0, fully free.
- Repo starred ✅ before submitting, per the guidelines.
- Individual PR per suggestion; checked for duplicates first.