### PR TITLE
Add: UpTrain and AgentOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
 - [LangWatch](https://github.com/langwatch/langwatch) 🆓💰 - Open-source LLM evaluation and AI agent testing platform combining end-to-end scenario simulation, observability, and prompt management in a single unified loop.
 - [Evidently](https://github.com/evidentlyai/evidently) 🆓💰 - Open-source Python library for evaluating, testing, and monitoring ML and LLM systems with 100+ built-in metrics for data quality, drift detection, and LLM output quality.
+- [UpTrain](https://github.com/uptrain-ai/uptrain) 🆓💰 - Open-source unified evaluation platform for LLM and GenAI applications with 20+ automated checks covering retrieval quality, context relevance, and response quality.
 - [LangSmith](https://www.langchain.com/langsmith) 💰 - LangChain's platform for testing and monitoring LLM apps.
 - [Braintrust](https://www.braintrust.dev/) 💰 - LLM eval platform with experiments, datasets, and observability.
 - [Patronus AI](https://www.patronus.ai/) 💰 - Automated evaluation and security testing for LLMs.
@@ -165,6 +166,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 AI for failure analysis, flaky test detection, and reporting.
 
 - [agenttrace](https://github.com/luoyuctl/agenttrace) 🆓 - Local-first TUI and CLI for evaluating AI coding agent sessions with cost, token, latency, and failure regression gates.
+- [AgentOps](https://github.com/AgentOps-AI/agentops) 🆓💰 - Open-source SDK for AI agent observability with step-by-step execution graphs, LLM cost tracking, session replays, and native integrations for CrewAI, LangChain, and major agent frameworks.
 - [ReportPortal](https://github.com/reportportal/reportportal) 🆓💰 - Open source results management with ML-based failure clustering.
 - [Allure TestOps](https://qameta.io/) 💰 - Test management with AI-driven analytics and flaky detection.
 - [Sealights](https://www.sealights.io/) 💰 - Quality intelligence platform using ML for test gap analysis.


### PR DESCRIPTION
Adds two actively maintained, well-known AI testing tools not yet in the list.

## UpTrain - LLM-as-Judge Evaluation

- **Repo:** https://github.com/uptrain-ai/uptrain
- **Stars:** 2.4k | **License:** Apache 2.0 | **Badge:** 🆓💰
- Open-source unified evaluation platform for LLM and GenAI applications with 20+ automated checks covering retrieval quality, context relevance, and response quality.
- Placed after Evidently, alongside similar open-source eval platforms.

## AgentOps - Test Analytics and Triage

- **Repo:** https://github.com/AgentOps-AI/agentops
- **Stars:** 5.8k | **License:** MIT | **Badge:** 🆓💰
- Open-source SDK for AI agent observability with step-by-step execution graphs, LLM cost tracking, session replays, and native integrations for CrewAI, LangChain, and major agent frameworks.
- Placed after agenttrace, the other AI agent-focused observability entry in the section.

Both entries follow the exact contribution format (linked name, badge, single sentence starting with uppercase and ending with a period, no em dash).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvqCDgUQJJbRt6WP64pxKb)_