### PR TITLE
Add: EvalPlus and LiveCodeBench to Benchmarks and Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ Learning resources for AI-powered testing.
 - [HELM](https://github.com/stanford-crfm/helm) 🆓 - Stanford CRFM's open-source Python framework for holistic, reproducible, and transparent evaluation of LLMs and multimodal models across dozens of scenarios covering accuracy, robustness, efficiency, bias, and safety.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
+- [EvalPlus](https://github.com/evalplus/evalplus) 🆓 - Rigorous LLM code evaluation framework that extends HumanEval and MBPP with up to 80x more hand-crafted test inputs to eliminate false-positive passing solutions.
+- [LiveCodeBench](https://github.com/LiveCodeBench/LiveCodeBench) 🆓 - Contamination-free coding benchmark that continuously collects fresh problems from LeetCode, AtCoder, and Codeforces to evaluate code generation, self-repair, and test prediction abilities.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.


### PR DESCRIPTION
Adds two well-known, actively maintained coding benchmarks to the **Benchmarks and Datasets** section, placed immediately after the existing HumanEval entry since both are code evaluation benchmarks.

## Entries added

**[EvalPlus](https://github.com/evalplus/evalplus)** (1.8k stars, last release Oct 2024)
- Rigorous LLM code evaluation framework that extends HumanEval (80x more tests) and MBPP (35x more tests) with hand-crafted inputs to expose false-positive passing solutions.
- Adopted by Meta (Llama), Qwen, and DeepSeek for benchmarking code generation models.
- Published at NeurIPS 2023; actively maintained with an EvalPerf efficiency track added in 2024.

**[LiveCodeBench](https://github.com/LiveCodeBench/LiveCodeBench)** (935 stars, dataset v6 April 2025)
- Contamination-free benchmark that continuously collects fresh competitive programming problems from LeetCode, AtCoder, and Codeforces.
- Evaluates code generation, self-repair, code execution, and test output prediction.
- Backed by academic research with a maintained live leaderboard.

Both entries follow the existing format: linked name, 🆓 badge, single sentence description starting with an uppercase letter and ending with a period. No em dashes used.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDD5rnDn5bpXKD2hKm3KZe)_