### PR TITLE
Add: Notte and LiveCodeBench

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Browser automation libraries designed for or commonly used by AI agents.
 - [Patchright](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright) 🆓 - Patched Playwright for stealth automation.
 - [Lightpanda](https://github.com/lightpanda-io/browser) 🆓 - Headless browser written in Zig, optimized for AI agents and scraping workloads.
 - [AgentQL](https://github.com/tinyfish-io/agentql) 🆓💰 - Natural language query language for AI agents to interact with and extract structured data from web pages, with self-healing selectors that integrate with Playwright.
+- [Notte](https://github.com/nottelabs/notte) 🆓 - Web agent framework for building fast, cost-efficient AI agents that automate web interactions using natural language instructions, with browser session management, structured data extraction, and anti-detection support.
 - [Browserbase](https://www.browserbase.com/) 💰 - Cloud browser infrastructure with natural language automation.
 
 ## Articles and Talks
@@ -296,6 +297,7 @@ Learning resources for AI-powered testing.
 - [HELM](https://github.com/stanford-crfm/helm) 🆓 - Stanford CRFM's open-source Python framework for holistic, reproducible, and transparent evaluation of LLMs and multimodal models across dozens of scenarios covering accuracy, robustness, efficiency, bias, and safety.
 - [SWE-bench](https://github.com/princeton-nlp/SWE-bench) - Benchmark for evaluating LLMs on real software engineering tasks, including test fixes.
 - [HumanEval](https://github.com/openai/human-eval) - Evaluating large language models trained on code.
+- [LiveCodeBench](https://github.com/LiveCodeBench/LiveCodeBench) 🆓 - Contamination-free holistic benchmark for evaluating LLM coding abilities that continuously collects problems from LeetCode, AtCoder, and CodeForces, covering code generation, execution, and test output prediction.
 - [WebArena](https://github.com/web-arena-x/webarena) - Self-hostable web environment for building and evaluating autonomous agents on realistic, multi-site tasks.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) 🆓 - NeurIPS 2024 benchmark for evaluating multimodal AI agents on open-ended tasks in real computer environments, supporting VMware, Docker, and AWS virtualization.
 - [tau-bench](https://github.com/sierra-research/tau-bench) - Benchmark for evaluating tool-using language agents through dynamic conversations with simulated users and domain-specific APIs.


### PR DESCRIPTION
## What this adds

Two new entries verified as active, well-maintained projects not previously listed.

### [Notte](https://github.com/nottelabs/notte) - Browser Automation for AI Agents

- 2,000+ stars, actively maintained
- Open-source web agent framework for building AI agents that automate web interactions using natural language instructions, with browser session management, structured data extraction, and anti-detection support
- Placed after AgentQL, before the commercial Browserbase entry

### [LiveCodeBench](https://github.com/LiveCodeBench/LiveCodeBench) - Benchmarks and Datasets

- 935 stars, active research project with ongoing dataset releases (v1 through v6)
- Contamination-free holistic benchmark for evaluating LLM coding abilities, continuously collecting problems from LeetCode, AtCoder, and CodeForces across code generation, execution, and test output prediction tasks
- Placed after HumanEval, alongside other code-focused benchmarks

Both entries follow the existing format (`- [Name](link) BADGE - Description.`) and were verified reachable before inclusion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4d2E1MjtVXziXQzsVQgFU)_