### PR TITLE
Add: qmax-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Tools and servers that use the Model Context Protocol to give AI agents browser 
 - [Podium MCP](https://github.com/hoainho/podium-mcp) 🆓 - MCP server purpose-built for mobile app testing on Android/iOS simulators using Maestro, with deep Redux state inspection and CI pipeline integration.
 - [Puppeteer MCP](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/puppeteer) 🆓 - Reference MCP server for Puppeteer-based browser automation from the official MCP servers repo.
 - [prufa-mcp](https://github.com/prufa-dev/prufa-mcp) 🆓💰 - Open-source (Apache-2.0) MCP server connected to Prufa's hosted audit backend; an AI agent runs a QA audit of a web app (analytics, broken flows, security headers, accessibility) and gets back machine-verified findings. First audit is free; further audits and features require a paid plan.
+- [qmax-mcp](https://github.com/Quality-Max/qmax-mcp) 🆓 - MCP server and CLI that gives coding agents independent QA evidence before declaring a web change done: scans a URL for console errors, broken links, accessibility, Core Web Vitals, SEO, and security headers, then generates and runs a deterministic Playwright repro behind a human-approval gate.
 
 ## Self-Healing Test Frameworks
 


### PR DESCRIPTION
## Summary

Adds [qmax-mcp](https://github.com/Quality-Max/qmax-mcp) to the MCP-Based Testing section, placed after prufa-mcp since both are QA-audit-oriented MCP servers.

qmax-mcp (`npx -y @qualitymax/qmax-mcp`, MIT, Node.js >=22.13.0) is an MCP server/CLI that gives coding agents independent QA evidence before declaring a web change done. It scans a URL for console errors, broken links, accessibility issues, Core Web Vitals/performance, SEO, security headers, cookies/trackers, mixed content, and page weight; inspects page structure for locator candidates; generates a deterministic Playwright repro from a finding; and runs a Playwright test behind a human-approval gate, returning structured evidence.

Disclosure: I'm affiliated with the project and am submitting on the maintainer's behalf.

## Checklist

- [x] Starred the repository per contributing.md
- [x] Used the required entry format `- [Name](link) BADGE - Description.`
- [x] Placed in the most relevant existing category (MCP-Based Testing)
- [x] Checked the README for duplicates before submitting
- [x] One tool per PR