### PR TITLE
Add: MLflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
 - [LangWatch](https://github.com/langwatch/langwatch) 🆓💰 - Open-source LLM evaluation and AI agent testing platform combining end-to-end scenario simulation, observability, and prompt management in a single unified loop.
 - [Evidently](https://github.com/evidentlyai/evidently) 🆓💰 - Open-source Python library for evaluating, testing, and monitoring ML and LLM systems with 100+ built-in metrics for data quality, drift detection, and LLM output quality.
+- [MLflow](https://github.com/mlflow/mlflow) 🆓 - Open-source AI engineering platform with 50+ built-in LLM judges and evaluation metrics for tracing, testing, and monitoring LLM applications and agents.
 - [LangSmith](https://www.langchain.com/langsmith) 💰 - LangChain's platform for testing and monitoring LLM apps.
 - [Braintrust](https://www.braintrust.dev/) 💰 - LLM eval platform with experiments, datasets, and observability.
 - [Patronus AI](https://www.patronus.ai/) 💰 - Automated evaluation and security testing for LLMs.


### PR DESCRIPTION
Adds [MLflow](https://github.com/mlflow/mlflow) to the **LLM-as-Judge Evaluation** section.

## Why MLflow

MLflow is one of the most widely adopted open-source AI/ML engineering platforms, with 27k+ GitHub stars and 13,000+ commits on an active master branch. It is licensed under Apache-2.0.

Its evaluation suite is a direct fit for this section:

- 50+ built-in LLM judges and evaluation metrics
- Trace-aware scoring across tool calls, reasoning chains, and planning steps in agentic workflows
- CI/CD-integrated regression detection to catch quality drops before production
- Experiment tracking so metric changes can be compared across model or prompt versions

MLflow is already widely used alongside other tools in this list (Langfuse, W&B Weave, Evidently) and is a natural companion for teams building and testing LLM applications.

## Entry added

```markdown
- [MLflow](https://github.com/mlflow/mlflow) 🆓 - Open-source AI engineering platform with 50+ built-in LLM judges and evaluation metrics for tracing, testing, and monitoring LLM applications and agents.
```

Placed after Evidently and before the commercial entries (LangSmith, Braintrust), consistent with the section's open-source - then - commercial ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqGhJ5ipa1wTHJBRCHwtH3

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqGhJ5ipa1wTHJBRCHwtH3)_