### PR TITLE
Add: MLflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [TruLens](https://github.com/truera/trulens) 🆓 - Evaluation framework for LLM apps with feedback functions and tracing.
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix) 🆓 - Open-source LLM observability and evaluation.
 - [Weights & Biases Weave](https://github.com/wandb/weave) 🆓💰 - Weights & Biases toolkit for tracing, debugging, and evaluating generative AI applications with built-in LLM-as-judge metrics and dataset management.
+- [MLflow](https://github.com/mlflow/mlflow) 🆓💰 - Open-source ML experiment tracking platform with built-in LLM evaluation, 50+ judge-based metrics, and tracing for prompts, RAG pipelines, and AI agents.
 - [OpenAI Evals](https://github.com/openai/evals) 🆓 - Framework for evaluating LLMs and an open-source registry of benchmarks from OpenAI. No longer actively maintained for new evals, but still widely used as a reference.
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) 🆓 - EleutherAI's framework for few-shot evaluation of language models, backing the Hugging Face Open LLM Leaderboard.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.


### PR DESCRIPTION
## What

Adds [MLflow](https://github.com/mlflow/mlflow) to the **LLM-as-Judge Evaluation** section.

## Why

MLflow is one of the most widely used ML experiment tracking platforms (27.8k stars, Apache-2.0) and has evolved into a first-class LLM evaluation tool. Its `mlflow.evaluate()` API ships with 50+ built-in judge-based metrics covering toxicity, relevance, faithfulness, and groundedness, plus native tracing for prompts, RAG pipelines, and AI agents. It is actively maintained and widely deployed in production ML teams.

The entry follows the existing format and fits alongside W&B Weave and TruLens in the observability-and-evaluation tier of that section.

## Checklist

- [x] The tool genuinely uses AI/ML as a core feature
- [x] Entry format matches existing entries (`- [Name](link) BADGE - Description.`)
- [x] Description is one sentence, starts uppercase, ends with a period
- [x] No duplicate - MLflow is not currently listed
- [x] Link verified as active and resolving correctly
- [x] No em dash or double hyphen used

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVHggCK5mZnRTazHAYiRr2)_