### PR TITLE
Add: YYLO Benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ AI for failure analysis, flaky test detection, and reporting.
 - [Launchable](https://www.launchableinc.com/) 💰 - ML-driven predictive test selection and flaky test detection.
 - [BuildPulse](https://buildpulse.io/) 💰 - Flaky test detection and analytics platform.
 - [flaky-test-detector](https://github.com/sametcelikbicak/flaky-test-detector) 🆓 - AI agent skill that detects, analyzes, and eliminates flaky tests across any test runner. Compatible with opencode, Claude Code, Cursor, Windsurf, and GitHub Copilot.
+- [YYLO Benchmark](https://github.com/yylo-dev/yylo-benchmark) 🆓 - Longitudinal evaluation and immutable evidence for agent runs: runs each candidate in a private fresh-repository workspace and evaluates retained evidence with ordered deterministic and LLM-judge profiles, keeping receipts, manifests, and provenance hash-verified.
 
 ## Code Coverage with AI
 


### PR DESCRIPTION
Adds [YYLO Benchmark](https://github.com/yylo-dev/yylo-benchmark) to **Test Analytics and Triage**.

- AI is core, not marketing: YYLO Benchmark is the isolated evaluation layer for coding-agent runs. Each candidate runs in a private fresh-repository workspace behind a selective filesystem sandbox, and retained evidence is evaluated with ordered deterministic and LLM-judge profiles (prompt, rubric, blinded/visible identity, strict JSON parsing). Doctor, report, and recovery fail closed unless every attempt's receipts, manifests, and provenance form one hash-verified chain.
- Placement: `agenttrace` ("Local-first TUI and CLI for evaluating AI coding agent sessions") is the closest sibling in this section. Happy to re-file to **LLM-as-Judge Evaluation** if that reads better — evaluator profiles support both deterministic commands and configurable LLM judges.
- Format followed: `- [Name](link) 🆓 - Description.` — MIT, fully free, on npm as `@yylo/benchmark` (also delegated unchanged by `yy benchmark` in the parent CLI).
- Repo starred ✅ before submitting, per the guidelines.
- Individual PR per suggestion; checked for duplicates first (no YYLO entries in the README).
- Disclosure: I'm on the team that builds YYLO, and this PR was prepared with AI assistance; every description phrase above is taken from the repo's own README/About.
