### PR TITLE
Add: OpenLLMetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Use LLMs to evaluate test outputs, assertions, and quality.
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) 🆓 - EleutherAI's framework for few-shot evaluation of language models, backing the Hugging Face Open LLM Leaderboard.
 - [Langfuse](https://github.com/langfuse/langfuse) 🆓💰 - Open source LLM observability, tracing, and evaluation platform.
 - [Helicone](https://github.com/Helicone/helicone) 🆓💰 - Open source LLM observability and prompt evaluation platform.
+- [OpenLLMetry](https://github.com/traceloop/openllmetry) 🆓 - OpenTelemetry-native observability for LLM and GenAI applications, with automatic instrumentation for 25+ AI providers and frameworks that routes traces to any existing observability backend.
 - [Opik](https://github.com/comet-ml/opik) 🆓💰 - Open-source LLM evaluation and observability platform with automated tracing, LLM-as-judge metrics, and pytest integration for CI pipelines.
 - [LangWatch](https://github.com/langwatch/langwatch) 🆓💰 - Open-source LLM evaluation and AI agent testing platform combining end-to-end scenario simulation, observability, and prompt management in a single unified loop.
 - [Evidently](https://github.com/evidentlyai/evidently) 🆓💰 - Open-source Python library for evaluating, testing, and monitoring ML and LLM systems with 100+ built-in metrics for data quality, drift detection, and LLM output quality.


### PR DESCRIPTION
Adds [OpenLLMetry](https://github.com/traceloop/openllmetry) to the **LLM-as-Judge Evaluation** section.

## What is it?

OpenLLMetry is an open-source (Apache 2.0) observability toolkit for LLM and GenAI applications built natively on OpenTelemetry. It automatically instruments calls to OpenAI, Anthropic, Cohere, and 25+ other providers as well as popular frameworks like LangChain and LlamaIndex, then routes the resulting traces to any existing observability backend - Datadog, Honeycomb, New Relic, and others.

- **GitHub**: https://github.com/traceloop/openllmetry
- **Stars**: 7.4k+
- **License**: Apache 2.0
- **Actively maintained**: yes (1,400+ commits, ongoing releases)

## Why add it?

The section already covers several LLM observability tools (Langfuse, Helicone, Arize Phoenix), but OpenLLMetry has a genuinely distinct angle: it is the only entry that is OpenTelemetry-native, meaning teams already on a standard observability stack (Datadog, Honeycomb, etc.) can adopt it without running a new dedicated platform. Its semantic conventions were contributed upstream and are now part of the OpenTelemetry specification itself.

## Checklist

- Single sentence description, starts with uppercase, ends with period
- Correct badge (🆓, Apache 2.0)
- No em dash
- Placed in the observability cluster of the LLM-as-Judge Evaluation section, between Helicone and Opik
- No duplicate - searched the full README before adding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4WNtXHsKdpRMxoRS9mmLk

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4WNtXHsKdpRMxoRS9mmLk)_